### PR TITLE
Implement TUI markdown editor with vim-like editing

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,0 +1,14 @@
+Generate a changelog from git history.
+
+1. Get commits since last tag (or all commits if no tags): `git log --oneline`
+2. Categorize commits into:
+   - **Added** - New features
+   - **Changed** - Changes to existing functionality
+   - **Fixed** - Bug fixes
+   - **Removed** - Removed features
+   - **Infrastructure** - CI, build, tooling changes
+3. Format as Keep a Changelog style (https://keepachangelog.com)
+4. If $ARGUMENTS contains a range (e.g., "v0.1.0..v0.2.0"), use that range
+5. Output the formatted changelog
+
+Do not create/write files unless the user explicitly asks.

--- a/.claude/commands/contrib-guide.md
+++ b/.claude/commands/contrib-guide.md
@@ -1,0 +1,13 @@
+Generate or update the CONTRIBUTING.md file for this open source project.
+
+Analyze the project to include:
+1. **Prerequisites** - Zig version, tools needed
+2. **Getting Started** - Clone, build, test commands
+3. **Development Workflow** - Branch naming, commit conventions, PR process
+4. **Code Style** - Reference `zig fmt`, any project-specific conventions from CLAUDE.md
+5. **Testing** - How to write and run tests
+6. **Project Structure** - Key directories and their purposes
+7. **Issue/PR Guidelines** - Templates, labels, review process
+
+Base everything on what actually exists in the repo (build.zig, CI config, existing docs).
+Show the draft before writing the file.

--- a/.claude/commands/issue-triage.md
+++ b/.claude/commands/issue-triage.md
@@ -1,0 +1,16 @@
+Triage GitHub issues for this repository. Argument: $ARGUMENTS
+
+If a specific issue number is given:
+1. Fetch the issue with `gh issue view <number>`
+2. Read related code to understand the scope
+3. Classify: bug / feature request / question / duplicate
+4. Suggest labels and priority
+5. Draft a response comment (show it, don't post without approval)
+
+If no argument or "list":
+1. Fetch open issues: `gh issue list --state open --limit 20`
+2. Summarize each with: title, age, labels, and a quick assessment
+3. Identify any that might be duplicates
+4. Suggest priority ordering
+
+Never post comments or close issues without explicit user approval.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,12 @@
+Prepare a release for the project. Version: $ARGUMENTS
+
+Steps:
+1. Check current version/tags: `git tag --sort=-v:refname | head -10`
+2. If no version arg given, suggest the next version based on commits since last tag
+3. Generate changelog from commits since last tag using conventional commit format
+4. Check that `zig build` and `zig build test` pass
+5. Show the release summary and wait for approval before:
+   - Creating the git tag
+   - Creating a GitHub release with `gh release create` including the changelog
+
+Do NOT push or create the release without explicit user confirmation.

--- a/.claude/commands/zig-build.md
+++ b/.claude/commands/zig-build.md
@@ -1,0 +1,11 @@
+Build the project with `zig build` and analyze the output:
+
+1. Run `zig build` (or `zig build $ARGUMENTS` if args provided)
+2. If build succeeds, report success and binary location
+3. If build fails, analyze the error:
+   - Read the failing source file(s)
+   - Explain the error in plain language
+   - Suggest or apply the fix
+   - Re-run the build to confirm
+
+For release builds, use: /zig-build -Doptimize=ReleaseSafe

--- a/.claude/commands/zig-check.md
+++ b/.claude/commands/zig-check.md
@@ -1,0 +1,9 @@
+Run a full project health check for the Zig codebase:
+
+1. Run `zig fmt --check src/` to find formatting issues — report any files that need formatting
+2. Run `zig build` to check for compilation errors
+3. Run `zig build test` to check for test failures
+4. Review build.zig for any dependency or configuration issues
+5. Check for common Zig anti-patterns in recently modified files (use `git diff --name-only` to find them)
+
+Report a summary with pass/fail status for each step. Fix any issues found if $ARGUMENTS contains "fix".

--- a/.claude/commands/zig-debug.md
+++ b/.claude/commands/zig-debug.md
@@ -1,0 +1,14 @@
+Debug a Zig issue. Argument: $ARGUMENTS
+
+Steps:
+1. If a specific error message or issue is described, search the codebase for related code
+2. If a file:line is given, read that location with context
+3. Analyze the issue considering Zig-specific patterns:
+   - Memory safety (use-after-free, buffer overflows, sentinel-terminated slices)
+   - Comptime vs runtime evaluation
+   - Optional/error union handling (orelse, catch, try)
+   - Allocator usage and ownership
+   - Packed struct alignment
+   - Build system integration
+4. Propose a fix with explanation
+5. If the fix is clear, apply it and run `zig build test` to verify

--- a/.claude/commands/zig-test.md
+++ b/.claude/commands/zig-test.md
@@ -1,0 +1,10 @@
+Run `zig build test` and analyze the results. If tests fail:
+
+1. Show which tests failed with their error messages
+2. Read the relevant source files to understand the failures
+3. Suggest fixes for each failing test
+4. If the fix is straightforward, apply it and re-run tests to confirm
+
+If all tests pass, report a summary of test count and any warnings.
+
+Optional argument: $ARGUMENTS (specific test filter or file to focus on)

--- a/.claude/hooks/zig-fmt.sh
+++ b/.claude/hooks/zig-fmt.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PostToolUse hook: auto-format .zig files after Edit/Write
+# Reads tool_input from stdin JSON to get the file path
+
+set -euo pipefail
+
+# Read JSON from stdin
+input=$(cat)
+
+# Extract file_path from tool_input using python3 (available on macOS)
+filepath=$(echo "$input" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('file_path', ''))
+" 2>/dev/null || true)
+
+# Skip if no file path or not a .zig file
+if [ -z "$filepath" ] || [[ "$filepath" != *.zig ]]; then
+    exit 0
+fi
+
+# Skip if file doesn't exist
+if [ ! -f "$filepath" ]; then
+    exit 0
+fi
+
+# Run zig fmt
+zig fmt "$filepath" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/zig-fmt.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Zig build artifacts
+zig-out/
+zig-cache/
+.zig-cache/
+.scrach
+
+# Local Claude config
+.claude.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# lazy-md
+
+Terminal-based markdown editor written in Zig. Inspired by lazygit/lazydocker.
+
+## Tech Stack
+
+- Language: Zig (0.13.0+)
+- File format: `.rndm` (100% backward compatible with `.md`)
+
+## Build Commands
+
+```bash
+zig build        # Build the project
+zig build run    # Run the editor
+zig build test   # Run tests
+```
+
+## Project Structure
+
+```
+src/
+  main.zig       # Entry point
+build.zig        # Build configuration
+build.zig.zon    # Package manifest
+```
+
+## Planned Features
+
+- TUI editor with vim-like navigation
+- Syntax highlighting
+- Built-in version control support
+- Markdown preview
+- Extensible plugin system
+- MCP connector for AI agent integration
+
+## Slash Commands
+
+Zig dev: `/zig-test`, `/zig-check`, `/zig-build`, `/zig-debug`
+OSS: `/release`, `/changelog`, `/issue-triage`, `/contrib-guide`
+
+## Hooks
+
+- `PostToolUse` on `Edit|Write`: auto-runs `zig fmt` on `.zig` files via `.claude/hooks/zig-fmt.sh`
+
+## Reference Projects
+
+- [lazygit](https://github.com/jesseduffield/lazygit)
+- [lazydocker](https://github.com/jesseduffield/lazydocker)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,109 @@
+# lazy-md
+
+A terminal-based markdown editor written in Zig. Inspired by [lazygit](https://github.com/jesseduffield/lazygit) and [lazydocker](https://github.com/jesseduffield/lazydocker).
+
+![Zig](https://img.shields.io/badge/Zig-0.15.1-f7a41d?logo=zig&logoColor=white)
+![License](https://img.shields.io/badge/license-MIT-blue)
+![Zero Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)
+
+## Features
+
+- **Vim-like modal editing** - Normal, Insert, and Command modes with familiar keybindings
+- **Markdown syntax highlighting** - Headers, bold, italic, code blocks, links, lists, blockquotes, strikethrough
+- **lazygit-style 3-panel layout** - File tree | Editor | Preview
+- **Gap buffer** with undo/redo stack
+- **Double-buffered rendering** with diff-based updates for flicker-free display
+- **`.rndm` file format** - 100% backward compatible with `.md`
+- **Zero external dependencies** - Pure Zig, built on POSIX termios + ANSI escape codes
+
+## Install
+
+Requires [Zig](https://ziglang.org/download/) 0.15.1+.
+
+```bash
+git clone https://github.com/user/lazy-md.git
+cd lazy-md
+zig build
+```
+
+The binary is at `zig-out/bin/lazy-md`.
+
+## Usage
+
+```bash
+# Open a file
+lazy-md myfile.md
+
+# Open in current directory (shows file tree)
+lazy-md
+```
+
+### Keybindings
+
+#### Normal Mode
+
+| Key | Action |
+|-----|--------|
+| `h` `j` `k` `l` | Move cursor left/down/up/right |
+| `w` `b` `e` | Word forward/backward/end |
+| `0` `$` `^` | Line start/end/first non-blank |
+| `gg` `G` | Go to top/bottom |
+| `i` `a` `o` `O` | Enter insert mode (before/after/below/above) |
+| `I` `A` | Insert at line start/end |
+| `x` | Delete character |
+| `dd` | Delete line |
+| `u` | Undo |
+| `Ctrl+R` | Redo |
+| `Ctrl+D` `Ctrl+U` | Half-page down/up |
+| `Ctrl+S` | Save |
+| `:` | Enter command mode |
+| `Tab` | Cycle panel focus |
+| `Alt+1` | Toggle file tree |
+| `Alt+2` | Toggle preview |
+
+#### Insert Mode
+
+| Key | Action |
+|-----|--------|
+| Type normally | Insert text |
+| `Escape` | Return to normal mode |
+| `Backspace` `Delete` | Delete character |
+| `Tab` | Insert 4 spaces |
+| Arrow keys | Move cursor |
+
+#### Commands
+
+| Command | Action |
+|---------|--------|
+| `:w` | Save |
+| `:q` | Quit (warns on unsaved changes) |
+| `:q!` | Force quit |
+| `:wq` `:x` | Save and quit |
+| `:w <path>` | Save as |
+| `:e <path>` | Open file |
+
+## Architecture
+
+```
+src/
+  main.zig             Entry point, CLI args, event loop
+  Terminal.zig          Raw mode, ANSI escape codes, colors
+  Input.zig             Key reading, escape sequence decoding
+  Buffer.zig            Gap buffer, undo/redo, file I/O
+  Editor.zig            Vim modes, cursor, scroll, rendering
+  Renderer.zig          Double-buffered cell grid, diff flush
+  markdown/syntax.zig   Markdown tokenizer + color theme
+  ui/Layout.zig         3-panel layout engine
+```
+
+## Development
+
+```bash
+zig build          # Build
+zig build run      # Run
+zig build test     # Run tests (19 tests)
+```
+
+## License
+
+MIT

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "lazy-md",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    b.installArtifact(exe);
+
+    // Run command
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run lazy-md");
+    run_step.dependOn(&run_cmd.step);
+
+    // Tests
+    const exe_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_exe_unit_tests.step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .fingerprint = 0x4aebeb4e93594792,
+    .name = .lazy_md,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.15.1",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/project.md
+++ b/project.md
@@ -1,0 +1,17 @@
+*.rndm (file format which 100% backward compatible with md)
+
+* a terminal based md editor, (obsidian alternative) just like lazy-git, lazy-docker. ....
+refer those repos
+use zig
+* it should include the basic features md editors, like shortcuts for navigation, formatting, and linking.
+* syntax highlighting, 
+* nice tui 
+* built in version control support
+* builtin markdown preview
+* an extendable plugin system
+
+
+* built in support to convert existing md files to rndm files (gd directory)
+
+
+finally that mcp connector we all want..so that agents mark the todos, dumb the intermediate steps, and finally the final product.

--- a/src/Buffer.zig
+++ b/src/Buffer.zig
@@ -1,0 +1,368 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Self = @This();
+
+const INITIAL_GAP: usize = 1024;
+const MIN_GAP: usize = 256;
+
+pub const Position = struct {
+    row: usize,
+    col: usize,
+};
+
+const UndoOp = union(enum) {
+    insert: struct { pos: usize, len: usize },
+    delete: struct { pos: usize, text: []const u8 },
+};
+
+// ── State ─────────────────────────────────────────────────────────────
+
+allocator: Allocator,
+data: []u8,
+gap_start: usize,
+gap_end: usize,
+line_starts: std.ArrayList(usize),
+dirty: bool,
+undo_stack: std.ArrayList(UndoOp),
+redo_stack: std.ArrayList(UndoOp),
+
+// ── Init / Deinit ─────────────────────────────────────────────────────
+
+pub fn init(allocator: Allocator) !Self {
+    const data = try allocator.alloc(u8, INITIAL_GAP);
+    var line_starts: std.ArrayList(usize) = .{};
+    try line_starts.append(allocator, 0);
+
+    return .{
+        .allocator = allocator,
+        .data = data,
+        .gap_start = 0,
+        .gap_end = INITIAL_GAP,
+        .line_starts = line_starts,
+        .dirty = false,
+        .undo_stack = .{},
+        .redo_stack = .{},
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.freeUndoStack();
+    self.freeRedoStack();
+    self.undo_stack.deinit(self.allocator);
+    self.redo_stack.deinit(self.allocator);
+    self.line_starts.deinit(self.allocator);
+    self.allocator.free(self.data);
+}
+
+fn freeUndoStack(self: *Self) void {
+    for (self.undo_stack.items) |op| {
+        switch (op) {
+            .delete => |d| self.allocator.free(d.text),
+            .insert => {},
+        }
+    }
+    self.undo_stack.clearRetainingCapacity();
+}
+
+fn freeRedoStack(self: *Self) void {
+    for (self.redo_stack.items) |op| {
+        switch (op) {
+            .delete => |d| self.allocator.free(d.text),
+            .insert => {},
+        }
+    }
+    self.redo_stack.clearRetainingCapacity();
+}
+
+// ── Content Access ────────────────────────────────────────────────────
+
+pub fn length(self: *const Self) usize {
+    return self.data.len - self.gapSize();
+}
+
+fn gapSize(self: *const Self) usize {
+    return self.gap_end - self.gap_start;
+}
+
+pub fn lineCount(self: *const Self) usize {
+    return self.line_starts.items.len;
+}
+
+pub fn getLine(self: *Self, line: usize) []const u8 {
+    if (line >= self.line_starts.items.len) return "";
+    const start = self.line_starts.items[line];
+    const end = if (line + 1 < self.line_starts.items.len)
+        self.line_starts.items[line + 1] - 1
+    else
+        self.length();
+    if (start >= end) return "";
+    // Move gap out of the way so we can return a contiguous slice
+    if (start < self.gap_start and end > self.gap_start) {
+        self.moveGap(end);
+    }
+    return self.sliceContent(start, end);
+}
+
+pub fn getLineLen(self: *const Self, line: usize) usize {
+    if (line >= self.line_starts.items.len) return 0;
+    const start = self.line_starts.items[line];
+    const end = if (line + 1 < self.line_starts.items.len)
+        self.line_starts.items[line + 1] - 1
+    else
+        self.length();
+    return end - start;
+}
+
+fn sliceContent(self: *const Self, start: usize, end: usize) []const u8 {
+    if (end <= self.gap_start) {
+        return self.data[start..end];
+    }
+    if (start >= self.gap_start) {
+        const real_start = start + self.gapSize();
+        const real_end = end + self.gapSize();
+        return self.data[real_start..real_end];
+    }
+    // Spans gap - return part before gap
+    return self.data[start..self.gap_start];
+}
+
+pub fn byteAt(self: *const Self, pos: usize) u8 {
+    if (pos < self.gap_start) return self.data[pos];
+    return self.data[pos + self.gapSize()];
+}
+
+// ── Editing ───────────────────────────────────────────────────────────
+
+pub fn insertChar(self: *Self, pos: usize, ch: u8) !void {
+    try self.insertSlice(pos, &[_]u8{ch});
+}
+
+pub fn insertSlice(self: *Self, pos: usize, text: []const u8) !void {
+    if (text.len == 0) return;
+    try self.ensureGap(text.len);
+    self.moveGap(pos);
+
+    @memcpy(self.data[self.gap_start .. self.gap_start + text.len], text);
+    self.gap_start += text.len;
+    self.dirty = true;
+
+    try self.undo_stack.append(self.allocator, .{ .insert = .{ .pos = pos, .len = text.len } });
+    self.freeRedoStack();
+    self.rebuildLineStarts();
+}
+
+pub fn deleteRange(self: *Self, pos: usize, len: usize) !void {
+    if (len == 0) return;
+    const deleted = try self.allocator.alloc(u8, len);
+    for (0..len) |i| {
+        deleted[i] = self.byteAt(pos + i);
+    }
+
+    self.moveGap(pos);
+    self.gap_end += len;
+    self.dirty = true;
+
+    try self.undo_stack.append(self.allocator, .{ .delete = .{ .pos = pos, .text = deleted } });
+    self.freeRedoStack();
+    self.rebuildLineStarts();
+}
+
+pub fn deleteChar(self: *Self, pos: usize) !void {
+    if (pos >= self.length()) return;
+    try self.deleteRange(pos, 1);
+}
+
+// ── Undo / Redo ───────────────────────────────────────────────────────
+
+pub fn undo(self: *Self) !void {
+    if (self.undo_stack.items.len == 0) return;
+    const op = self.undo_stack.pop() orelse return;
+    switch (op) {
+        .insert => |ins| {
+            const deleted = try self.allocator.alloc(u8, ins.len);
+            for (0..ins.len) |i| {
+                deleted[i] = self.byteAt(ins.pos + i);
+            }
+            self.moveGap(ins.pos);
+            self.gap_end += ins.len;
+            try self.redo_stack.append(self.allocator, .{ .delete = .{ .pos = ins.pos, .text = deleted } });
+            self.rebuildLineStarts();
+        },
+        .delete => |del| {
+            try self.ensureGap(del.text.len);
+            self.moveGap(del.pos);
+            @memcpy(self.data[self.gap_start .. self.gap_start + del.text.len], del.text);
+            self.gap_start += del.text.len;
+            try self.redo_stack.append(self.allocator, .{ .insert = .{ .pos = del.pos, .len = del.text.len } });
+            self.allocator.free(del.text);
+            self.rebuildLineStarts();
+        },
+    }
+    self.dirty = true;
+}
+
+pub fn redo(self: *Self) !void {
+    if (self.redo_stack.items.len == 0) return;
+    const op = self.redo_stack.pop() orelse return;
+    switch (op) {
+        .delete => |del| {
+            self.moveGap(del.pos);
+            self.gap_end += del.text.len;
+            try self.undo_stack.append(self.allocator, .{ .delete = .{ .pos = del.pos, .text = del.text } });
+            self.rebuildLineStarts();
+        },
+        .insert => |ins| {
+            try self.undo_stack.append(self.allocator, .{ .insert = .{ .pos = ins.pos, .len = ins.len } });
+            self.rebuildLineStarts();
+        },
+    }
+    self.dirty = true;
+}
+
+// ── Position Conversion ───────────────────────────────────────────────
+
+pub fn posToOffset(self: *const Self, row: usize, col: usize) usize {
+    if (row >= self.line_starts.items.len) return self.length();
+    const line_start = self.line_starts.items[row];
+    const line_len = self.getLineLen(row);
+    return line_start + @min(col, line_len);
+}
+
+pub fn offsetToPos(self: *const Self, offset: usize) Position {
+    var row: usize = 0;
+    for (self.line_starts.items, 0..) |start, i| {
+        if (start > offset) break;
+        row = i;
+    }
+    return .{ .row = row, .col = offset - self.line_starts.items[row] };
+}
+
+// ── File I/O ──────────────────────────────────────────────────────────
+
+pub fn loadFile(self: *Self, path: []const u8) !void {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    const stat = try file.stat();
+    const size = stat.size;
+
+    const new_cap = size + INITIAL_GAP;
+    self.allocator.free(self.data);
+    self.data = try self.allocator.alloc(u8, new_cap);
+
+    const bytes_read = try file.readAll(self.data[0..size]);
+    self.gap_start = bytes_read;
+    self.gap_end = new_cap;
+    self.dirty = false;
+
+    self.freeUndoStack();
+    self.freeRedoStack();
+    self.rebuildLineStarts();
+}
+
+pub fn saveFile(self: *Self, path: []const u8) !void {
+    const file = try std.fs.cwd().createFile(path, .{});
+    defer file.close();
+
+    if (self.gap_start > 0) {
+        try file.writeAll(self.data[0..self.gap_start]);
+    }
+    if (self.gap_end < self.data.len) {
+        try file.writeAll(self.data[self.gap_end..]);
+    }
+    self.dirty = false;
+}
+
+// ── Internal ──────────────────────────────────────────────────────────
+
+fn moveGap(self: *Self, pos: usize) void {
+    if (pos == self.gap_start) return;
+    if (pos < self.gap_start) {
+        const move_len = self.gap_start - pos;
+        const src = self.data[pos..self.gap_start];
+        const dest_start = self.gap_end - move_len;
+        std.mem.copyBackwards(u8, self.data[dest_start..self.gap_end], src);
+        self.gap_start = pos;
+        self.gap_end = dest_start;
+    } else {
+        const move_len = pos - self.gap_start;
+        const src = self.data[self.gap_end .. self.gap_end + move_len];
+        @memcpy(self.data[self.gap_start .. self.gap_start + move_len], src);
+        self.gap_start += move_len;
+        self.gap_end += move_len;
+    }
+}
+
+fn ensureGap(self: *Self, needed: usize) !void {
+    if (self.gapSize() >= needed + MIN_GAP) return;
+    const new_gap = @max(needed + INITIAL_GAP, self.data.len / 2);
+    const old_len = self.data.len;
+    const new_len = old_len + new_gap - self.gapSize() + needed;
+
+    const new_data = try self.allocator.alloc(u8, new_len);
+    @memcpy(new_data[0..self.gap_start], self.data[0..self.gap_start]);
+    const after_gap_len = old_len - self.gap_end;
+    const new_gap_end = new_len - after_gap_len;
+    @memcpy(new_data[new_gap_end..], self.data[self.gap_end..]);
+
+    self.allocator.free(self.data);
+    self.data = new_data;
+    self.gap_end = new_gap_end;
+}
+
+fn rebuildLineStarts(self: *Self) void {
+    self.line_starts.clearRetainingCapacity();
+    self.line_starts.append(self.allocator, 0) catch return;
+    const total = self.length();
+    for (0..total) |i| {
+        if (self.byteAt(i) == '\n') {
+            self.line_starts.append(self.allocator, i + 1) catch return;
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "insert and read" {
+    var buf = try init(std.testing.allocator);
+    defer buf.deinit();
+
+    try buf.insertSlice(0, "Hello\nWorld");
+    try std.testing.expectEqual(@as(usize, 11), buf.length());
+    try std.testing.expectEqual(@as(usize, 2), buf.lineCount());
+    try std.testing.expectEqualStrings("Hello", buf.getLine(0));
+    try std.testing.expectEqualStrings("World", buf.getLine(1));
+}
+
+test "delete" {
+    var buf = try init(std.testing.allocator);
+    defer buf.deinit();
+
+    try buf.insertSlice(0, "ABCDE");
+    try buf.deleteRange(1, 2);
+    try std.testing.expectEqual(@as(usize, 3), buf.length());
+    try std.testing.expectEqualStrings("ADE", buf.getLine(0));
+}
+
+test "undo insert" {
+    var buf = try init(std.testing.allocator);
+    defer buf.deinit();
+
+    try buf.insertSlice(0, "Hello");
+    try std.testing.expectEqual(@as(usize, 5), buf.length());
+    try buf.undo();
+    try std.testing.expectEqual(@as(usize, 0), buf.length());
+}
+
+test "position conversion" {
+    var buf = try init(std.testing.allocator);
+    defer buf.deinit();
+
+    try buf.insertSlice(0, "Line1\nLine2\nLine3");
+    const pos = buf.offsetToPos(7);
+    try std.testing.expectEqual(@as(usize, 1), pos.row);
+    try std.testing.expectEqual(@as(usize, 1), pos.col);
+
+    const off = buf.posToOffset(2, 3);
+    try std.testing.expectEqual(@as(usize, 15), off);
+}

--- a/src/Editor.zig
+++ b/src/Editor.zig
@@ -1,0 +1,722 @@
+const std = @import("std");
+const Buffer = @import("Buffer.zig");
+const Input = @import("Input.zig");
+const Key = Input.Key;
+const Renderer = @import("Renderer.zig");
+const Terminal = @import("Terminal.zig");
+const syntax = @import("markdown/syntax.zig");
+const Self = @This();
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+pub const Mode = enum {
+    normal,
+    insert,
+    command,
+};
+
+pub const StatusMsg = struct {
+    text: [256]u8 = undefined,
+    len: usize = 0,
+    is_error: bool = false,
+
+    pub fn set(self: *StatusMsg, msg: []const u8, err: bool) void {
+        const copy_len = @min(msg.len, self.text.len);
+        @memcpy(self.text[0..copy_len], msg[0..copy_len]);
+        self.len = copy_len;
+        self.is_error = err;
+    }
+
+    pub fn slice(self: *const StatusMsg) []const u8 {
+        return self.text[0..self.len];
+    }
+};
+
+// ── State ─────────────────────────────────────────────────────────────
+
+buffer: Buffer,
+allocator: std.mem.Allocator,
+// Cursor (0-indexed)
+cursor_row: usize = 0,
+cursor_col: usize = 0,
+// Desired column for vertical movement
+desired_col: usize = 0,
+// Scroll offset
+scroll_row: usize = 0,
+scroll_col: usize = 0,
+// Editor viewport (set by layout)
+view_x: u16 = 0,
+view_y: u16 = 0,
+view_width: u16 = 80,
+view_height: u16 = 24,
+// Mode
+mode: Mode = .normal,
+// Command line
+cmd_buf: [256]u8 = undefined,
+cmd_len: usize = 0,
+// File path
+file_path: ?[]const u8 = null,
+file_path_owned: ?[]u8 = null,
+// Status message
+status: StatusMsg = .{},
+// Quit flag
+should_quit: bool = false,
+// Syntax state
+line_ctx: syntax.LineContext = .{},
+spans: std.ArrayList(syntax.Span) = .{},
+// Count prefix for vim commands
+count: usize = 0,
+// Pending operator (d, c, y)
+pending_op: ?u21 = null,
+
+// ── Init / Deinit ─────────────────────────────────────────────────────
+
+pub fn init(allocator: std.mem.Allocator) !Self {
+    return .{
+        .buffer = try Buffer.init(allocator),
+        .allocator = allocator,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.spans.deinit(self.allocator);
+    self.buffer.deinit();
+    if (self.file_path_owned) |p| self.allocator.free(p);
+}
+
+pub fn openFile(self: *Self, path: []const u8) !void {
+    try self.buffer.loadFile(path);
+    const owned = try self.allocator.dupe(u8, path);
+    if (self.file_path_owned) |old| self.allocator.free(old);
+    self.file_path_owned = owned;
+    self.file_path = owned;
+    self.cursor_row = 0;
+    self.cursor_col = 0;
+    self.scroll_row = 0;
+    self.status.set("File opened", false);
+}
+
+// ── Input Dispatch ────────────────────────────────────────────────────
+
+pub fn handleEvent(self: *Self, event: Input.Event) !void {
+    switch (event) {
+        .key => |key| switch (self.mode) {
+            .normal => try self.handleNormal(key),
+            .insert => try self.handleInsert(key),
+            .command => try self.handleCommand(key),
+        },
+        .resize => {},
+        .none => {},
+    }
+}
+
+// ── Normal Mode ───────────────────────────────────────────────────────
+
+fn handleNormal(self: *Self, key: Key) !void {
+    // Ctrl shortcuts
+    if (key.ctrl) {
+        switch (key.code) {
+            .char => |c| switch (c) {
+                's' => try self.save(),
+                'u' => {
+                    const n = if (self.count > 0) self.count else @as(usize, self.view_height / 2);
+                    self.count = 0;
+                    for (0..n) |_| self.moveCursorUp();
+                },
+                'd' => {
+                    const n = if (self.count > 0) self.count else @as(usize, self.view_height / 2);
+                    self.count = 0;
+                    for (0..n) |_| self.moveCursorDown();
+                },
+                'r' => try self.buffer.redo(),
+                else => {},
+            },
+            else => {},
+        }
+        return;
+    }
+
+    switch (key.code) {
+        .char => |c| {
+            // Count prefix
+            if (c >= '1' and c <= '9' and self.count == 0 and self.pending_op == null) {
+                self.count = c - '0';
+                return;
+            }
+            if (c >= '0' and c <= '9' and self.count > 0) {
+                self.count = self.count * 10 + (c - '0');
+                return;
+            }
+
+            const n = if (self.count > 0) self.count else 1;
+            self.count = 0;
+
+            // Handle pending operator
+            if (self.pending_op) |op| {
+                self.pending_op = null;
+                switch (op) {
+                    'd' => {
+                        if (c == 'd') {
+                            for (0..n) |_| try self.deleteLine();
+                        }
+                    },
+                    else => {},
+                }
+                return;
+            }
+
+            switch (c) {
+                // Movement
+                'h' => for (0..n) |_| self.moveCursorLeft(),
+                'j' => for (0..n) |_| self.moveCursorDown(),
+                'k' => for (0..n) |_| self.moveCursorUp(),
+                'l' => for (0..n) |_| self.moveCursorRight(),
+                'w' => for (0..n) |_| self.wordForward(),
+                'b' => for (0..n) |_| self.wordBackward(),
+                'e' => for (0..n) |_| self.wordEnd(),
+                '0' => self.cursor_col = 0,
+                '$' => self.cursorToLineEnd(),
+                '^' => self.cursorToFirstNonBlank(),
+
+                // Entering insert mode
+                'i' => self.mode = .insert,
+                'I' => {
+                    self.cursorToFirstNonBlank();
+                    self.mode = .insert;
+                },
+                'a' => {
+                    self.moveCursorRight();
+                    self.mode = .insert;
+                },
+                'A' => {
+                    self.cursorToLineEnd();
+                    self.moveCursorRight();
+                    self.mode = .insert;
+                },
+                'o' => {
+                    self.cursorToLineEnd();
+                    const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+                    try self.buffer.insertChar(offset, '\n');
+                    self.cursor_row += 1;
+                    self.cursor_col = 0;
+                    self.mode = .insert;
+                },
+                'O' => {
+                    const line_start = self.buffer.posToOffset(self.cursor_row, 0);
+                    try self.buffer.insertChar(line_start, '\n');
+                    self.cursor_col = 0;
+                    self.mode = .insert;
+                },
+
+                // Editing
+                'x' => {
+                    for (0..n) |_| {
+                        const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+                        if (offset < self.buffer.length()) {
+                            try self.buffer.deleteChar(offset);
+                        }
+                    }
+                    self.clampCursor();
+                },
+                'd' => self.pending_op = 'd',
+                'u' => try self.buffer.undo(),
+                'p' => {}, // paste (TODO: clipboard)
+
+                // Jumps
+                'g' => self.cursor_row = 0,
+                'G' => {
+                    self.cursor_row = if (self.buffer.lineCount() > 0) self.buffer.lineCount() - 1 else 0;
+                },
+
+                // Command mode
+                ':' => {
+                    self.mode = .command;
+                    self.cmd_len = 0;
+                },
+
+                else => {},
+            }
+        },
+        .up => self.moveCursorUp(),
+        .down => self.moveCursorDown(),
+        .left => self.moveCursorLeft(),
+        .right => self.moveCursorRight(),
+        .home => self.cursor_col = 0,
+        .end => self.cursorToLineEnd(),
+        .page_up => {
+            for (0..self.view_height) |_| self.moveCursorUp();
+        },
+        .page_down => {
+            for (0..self.view_height) |_| self.moveCursorDown();
+        },
+        else => {},
+    }
+}
+
+// ── Insert Mode ───────────────────────────────────────────────────────
+
+fn handleInsert(self: *Self, key: Key) !void {
+    if (key.code == .escape) {
+        self.mode = .normal;
+        if (self.cursor_col > 0) self.cursor_col -= 1;
+        return;
+    }
+
+    if (key.ctrl) {
+        switch (key.code) {
+            .char => |c| switch (c) {
+                's' => try self.save(),
+                else => {},
+            },
+            else => {},
+        }
+        return;
+    }
+
+    switch (key.code) {
+        .char => |c| {
+            var buf: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(c, &buf) catch return;
+            const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+            try self.buffer.insertSlice(offset, buf[0..len]);
+            self.cursor_col += 1;
+        },
+        .enter => {
+            const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+            try self.buffer.insertChar(offset, '\n');
+            self.cursor_row += 1;
+            self.cursor_col = 0;
+        },
+        .backspace => {
+            const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+            if (offset > 0) {
+                const prev_byte = self.buffer.byteAt(offset - 1);
+                try self.buffer.deleteChar(offset - 1);
+                if (prev_byte == '\n') {
+                    if (self.cursor_row > 0) {
+                        self.cursor_row -= 1;
+                        self.cursor_col = self.buffer.getLineLen(self.cursor_row);
+                    }
+                } else {
+                    if (self.cursor_col > 0) self.cursor_col -= 1;
+                }
+            }
+        },
+        .delete => {
+            const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+            if (offset < self.buffer.length()) {
+                try self.buffer.deleteChar(offset);
+            }
+        },
+        .tab => {
+            const offset = self.buffer.posToOffset(self.cursor_row, self.cursor_col);
+            try self.buffer.insertSlice(offset, "    ");
+            self.cursor_col += 4;
+        },
+        .up => self.moveCursorUp(),
+        .down => self.moveCursorDown(),
+        .left => self.moveCursorLeft(),
+        .right => self.moveCursorRight(),
+        .home => self.cursor_col = 0,
+        .end => self.cursorToLineEnd(),
+        else => {},
+    }
+}
+
+// ── Command Mode ──────────────────────────────────────────────────────
+
+fn handleCommand(self: *Self, key: Key) !void {
+    switch (key.code) {
+        .escape => {
+            self.mode = .normal;
+            self.cmd_len = 0;
+        },
+        .enter => {
+            try self.executeCommand();
+            self.mode = .normal;
+        },
+        .backspace => {
+            if (self.cmd_len > 0) {
+                self.cmd_len -= 1;
+            } else {
+                self.mode = .normal;
+            }
+        },
+        .char => |c| {
+            if (c < 128 and self.cmd_len < self.cmd_buf.len) {
+                self.cmd_buf[self.cmd_len] = @intCast(c);
+                self.cmd_len += 1;
+            }
+        },
+        else => {},
+    }
+}
+
+fn executeCommand(self: *Self) !void {
+    const cmd = self.cmd_buf[0..self.cmd_len];
+
+    if (std.mem.eql(u8, cmd, "q") or std.mem.eql(u8, cmd, "quit")) {
+        if (self.buffer.dirty) {
+            self.status.set("Unsaved changes! Use :q! to force quit or :wq to save and quit", true);
+            return;
+        }
+        self.should_quit = true;
+    } else if (std.mem.eql(u8, cmd, "q!")) {
+        self.should_quit = true;
+    } else if (std.mem.eql(u8, cmd, "w") or std.mem.eql(u8, cmd, "write")) {
+        try self.save();
+    } else if (std.mem.eql(u8, cmd, "wq") or std.mem.eql(u8, cmd, "x")) {
+        try self.save();
+        self.should_quit = true;
+    } else if (std.mem.startsWith(u8, cmd, "w ")) {
+        const path = std.mem.trimLeft(u8, cmd[2..], " ");
+        if (path.len > 0) {
+            try self.saveAs(path);
+        }
+    } else if (std.mem.startsWith(u8, cmd, "e ")) {
+        const path = std.mem.trimLeft(u8, cmd[2..], " ");
+        if (path.len > 0) {
+            self.openFile(path) catch {
+                self.status.set("Failed to open file", true);
+            };
+        }
+    } else {
+        self.status.set("Unknown command", true);
+    }
+}
+
+// ── Cursor Movement ───────────────────────────────────────────────────
+
+fn moveCursorUp(self: *Self) void {
+    if (self.cursor_row > 0) {
+        self.cursor_row -= 1;
+        self.cursor_col = @min(self.desired_col, self.buffer.getLineLen(self.cursor_row));
+    }
+}
+
+fn moveCursorDown(self: *Self) void {
+    if (self.cursor_row + 1 < self.buffer.lineCount()) {
+        self.cursor_row += 1;
+        self.cursor_col = @min(self.desired_col, self.buffer.getLineLen(self.cursor_row));
+    }
+}
+
+fn moveCursorLeft(self: *Self) void {
+    if (self.cursor_col > 0) {
+        self.cursor_col -= 1;
+        self.desired_col = self.cursor_col;
+    }
+}
+
+fn moveCursorRight(self: *Self) void {
+    const line_len = self.buffer.getLineLen(self.cursor_row);
+    const max_col = if (self.mode == .insert) line_len else if (line_len > 0) line_len - 1 else 0;
+    if (self.cursor_col < max_col) {
+        self.cursor_col += 1;
+        self.desired_col = self.cursor_col;
+    }
+}
+
+fn cursorToLineEnd(self: *Self) void {
+    const len = self.buffer.getLineLen(self.cursor_row);
+    self.cursor_col = if (len > 0 and self.mode == .normal) len - 1 else len;
+    self.desired_col = std.math.maxInt(usize);
+}
+
+fn cursorToFirstNonBlank(self: *Self) void {
+    const line = self.buffer.getLine(self.cursor_row);
+    var col: usize = 0;
+    while (col < line.len and (line[col] == ' ' or line[col] == '\t')) : (col += 1) {}
+    self.cursor_col = col;
+    self.desired_col = col;
+}
+
+fn wordForward(self: *Self) void {
+    const line = self.buffer.getLine(self.cursor_row);
+    var col = self.cursor_col;
+    // Skip current word
+    while (col < line.len and !isWordSep(line[col])) : (col += 1) {}
+    // Skip spaces
+    while (col < line.len and isWordSep(line[col])) : (col += 1) {}
+    if (col >= line.len and self.cursor_row + 1 < self.buffer.lineCount()) {
+        self.cursor_row += 1;
+        self.cursor_col = 0;
+        self.cursorToFirstNonBlank();
+    } else {
+        self.cursor_col = col;
+    }
+    self.desired_col = self.cursor_col;
+}
+
+fn wordBackward(self: *Self) void {
+    const line = self.buffer.getLine(self.cursor_row);
+    var col = self.cursor_col;
+    if (col == 0) {
+        if (self.cursor_row > 0) {
+            self.cursor_row -= 1;
+            self.cursorToLineEnd();
+        }
+        return;
+    }
+    col -= 1;
+    // Skip spaces
+    while (col > 0 and isWordSep(line[col])) : (col -= 1) {}
+    // Skip word
+    while (col > 0 and !isWordSep(line[col - 1])) : (col -= 1) {}
+    self.cursor_col = col;
+    self.desired_col = col;
+}
+
+fn wordEnd(self: *Self) void {
+    const line = self.buffer.getLine(self.cursor_row);
+    var col = self.cursor_col + 1;
+    // Skip spaces
+    while (col < line.len and isWordSep(line[col])) : (col += 1) {}
+    // Skip word
+    while (col < line.len and !isWordSep(line[col])) : (col += 1) {}
+    self.cursor_col = if (col > 0) col - 1 else 0;
+    self.desired_col = self.cursor_col;
+}
+
+fn isWordSep(c: u8) bool {
+    return c == ' ' or c == '\t' or c == '\n' or c == '.' or c == ',' or
+        c == ';' or c == ':' or c == '(' or c == ')' or c == '[' or
+        c == ']' or c == '{' or c == '}';
+}
+
+fn clampCursor(self: *Self) void {
+    const line_len = self.buffer.getLineLen(self.cursor_row);
+    if (self.mode == .normal and line_len > 0) {
+        self.cursor_col = @min(self.cursor_col, line_len - 1);
+    } else {
+        self.cursor_col = @min(self.cursor_col, line_len);
+    }
+}
+
+fn deleteLine(self: *Self) !void {
+    const line_count = self.buffer.lineCount();
+    if (line_count == 0) return;
+
+    const start = self.buffer.posToOffset(self.cursor_row, 0);
+    var end: usize = undefined;
+    if (self.cursor_row + 1 < line_count) {
+        end = self.buffer.posToOffset(self.cursor_row + 1, 0);
+    } else {
+        end = self.buffer.length();
+        // Include preceding newline if not first line
+        if (self.cursor_row > 0 and start > 0) {
+            try self.buffer.deleteRange(start - 1, end - start + 1);
+            self.cursor_row -= 1;
+            self.clampCursor();
+            return;
+        }
+    }
+
+    if (end > start) {
+        try self.buffer.deleteRange(start, end - start);
+    }
+    if (self.cursor_row >= self.buffer.lineCount() and self.cursor_row > 0) {
+        self.cursor_row -= 1;
+    }
+    self.clampCursor();
+}
+
+// ── Scroll Management ─────────────────────────────────────────────────
+
+pub fn updateScroll(self: *Self) void {
+    // Vertical
+    if (self.cursor_row < self.scroll_row) {
+        self.scroll_row = self.cursor_row;
+    }
+    if (self.cursor_row >= self.scroll_row + self.view_height) {
+        self.scroll_row = self.cursor_row - self.view_height + 1;
+    }
+    // Horizontal
+    if (self.cursor_col < self.scroll_col) {
+        self.scroll_col = self.cursor_col;
+    }
+    if (self.cursor_col >= self.scroll_col + self.view_width) {
+        self.scroll_col = self.cursor_col - self.view_width + 1;
+    }
+}
+
+// ── File Operations ───────────────────────────────────────────────────
+
+fn save(self: *Self) !void {
+    if (self.file_path) |path| {
+        try self.buffer.saveFile(path);
+        self.status.set("File saved", false);
+    } else {
+        self.status.set("No filename. Use :w <filename>", true);
+    }
+}
+
+fn saveAs(self: *Self, path: []const u8) !void {
+    try self.buffer.saveFile(path);
+    const owned = try self.allocator.dupe(u8, path);
+    if (self.file_path_owned) |old| self.allocator.free(old);
+    self.file_path_owned = owned;
+    self.file_path = owned;
+    self.status.set("File saved", false);
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────
+
+pub fn render(self: *Self, renderer: *Renderer) !void {
+    self.updateScroll();
+
+    // Reset syntax context for visible lines
+    self.line_ctx = .{};
+
+    // Pre-scan for code blocks before visible area
+    for (0..self.scroll_row) |row| {
+        if (row >= self.buffer.lineCount()) break;
+        const line = self.buffer.getLine(row);
+        if (syntax.isCodeFence(line)) {
+            self.line_ctx.in_code_block = !self.line_ctx.in_code_block;
+        }
+    }
+
+    // Draw line numbers + content
+    const vx = self.view_x;
+    const vy = self.view_y;
+
+    // Line number gutter width
+    const gutter_w: u16 = 4;
+
+    for (0..self.view_height) |screen_row| {
+        const buf_row = self.scroll_row + screen_row;
+        const y = vy + @as(u16, @intCast(screen_row));
+
+        if (buf_row >= self.buffer.lineCount()) {
+            // Tilde for empty lines
+            renderer.putChar(vx, y, '~', .bright_black, .default, .{});
+            continue;
+        }
+
+        // Line number
+        var num_buf: [8]u8 = undefined;
+        const num_str = std.fmt.bufPrint(&num_buf, "{d: >3} ", .{buf_row + 1}) catch "??? ";
+        const num_color: Terminal.Color = if (buf_row == self.cursor_row) .bright_white else .bright_black;
+        renderer.putStr(vx, y, num_str, num_color, .default, .{});
+
+        // Line content with syntax highlighting
+        const line = self.buffer.getLine(buf_row);
+        try syntax.tokenizeLine(self.allocator, line, &self.line_ctx, &self.spans);
+
+        if (self.spans.items.len == 0) continue;
+
+        for (self.spans.items) |span| {
+            const fg = syntax.Theme.getFg(span.token);
+            const bg = syntax.Theme.getBg(span.token);
+            const style = syntax.Theme.getStyle(span.token);
+
+            const text = line[span.start..span.end];
+            var col: u16 = @intCast(span.start);
+            for (text) |ch| {
+                if (col >= self.scroll_col and col - @as(u16, @intCast(self.scroll_col)) + gutter_w < self.view_width) {
+                    const screen_col = vx + gutter_w + @as(u16, @intCast(col)) - @as(u16, @intCast(self.scroll_col));
+                    renderer.putChar(screen_col, y, ch, fg, bg, style);
+                }
+                col += 1;
+            }
+        }
+
+        // Cursor highlight in this row
+        if (buf_row == self.cursor_row) {
+            const cx = vx + gutter_w + @as(u16, @intCast(self.cursor_col)) -| @as(u16, @intCast(self.scroll_col));
+            if (cx < vx + self.view_width) {
+                const idx = @as(usize, y) * @as(usize, renderer.width) + @as(usize, cx);
+                if (idx < renderer.back.len) {
+                    renderer.back[idx].style.reverse = true;
+                }
+            }
+        }
+    }
+}
+
+pub fn renderStatusBar(self: *Self, renderer: *Renderer, y: u16) void {
+    // Fill status bar background
+    renderer.fillRow(y, ' ', .bright_white, .{ .fixed = 236 }, .{});
+
+    // Mode indicator
+    const mode_str = switch (self.mode) {
+        .normal => " NORMAL ",
+        .insert => " INSERT ",
+        .command => " COMMAND ",
+    };
+    const mode_bg: Terminal.Color = switch (self.mode) {
+        .normal => .blue,
+        .insert => .green,
+        .command => .magenta,
+    };
+    renderer.putStr(0, y, mode_str, .bright_white, mode_bg, .{ .bold = true });
+
+    // Filename + dirty indicator
+    const name = self.file_path orelse "[No File]";
+    const dirty_str: []const u8 = if (self.buffer.dirty) " [+]" else "";
+    var file_buf: [128]u8 = undefined;
+    const file_str = std.fmt.bufPrint(&file_buf, " {s}{s}", .{ name, dirty_str }) catch " ???";
+    renderer.putStr(@intCast(mode_str.len), y, file_str, .white, .{ .fixed = 236 }, .{});
+
+    // Position info (right-aligned)
+    var pos_buf: [32]u8 = undefined;
+    const pos_str = std.fmt.bufPrint(&pos_buf, "Ln {d}, Col {d} ", .{ self.cursor_row + 1, self.cursor_col + 1 }) catch "";
+    if (pos_str.len < renderer.width) {
+        renderer.putStr(@intCast(renderer.width - @as(u16, @intCast(pos_str.len))), y, pos_str, .white, .{ .fixed = 236 }, .{});
+    }
+}
+
+pub fn renderCommandBar(self: *Self, renderer: *Renderer, y: u16) void {
+    if (self.mode == .command) {
+        renderer.putChar(0, y, ':', .bright_white, .default, .{ .bold = true });
+        renderer.putStr(1, y, self.cmd_buf[0..self.cmd_len], .white, .default, .{});
+    } else if (self.status.len > 0) {
+        const fg: Terminal.Color = if (self.status.is_error) .bright_red else .bright_green;
+        renderer.putStr(0, y, self.status.slice(), fg, .default, .{});
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "editor init and insert" {
+    var editor = try init(std.testing.allocator);
+    defer editor.deinit();
+
+    try std.testing.expectEqual(Mode.normal, editor.mode);
+
+    // Simulate 'i' to enter insert mode
+    try editor.handleEvent(.{ .key = Key.char('i') });
+    try std.testing.expectEqual(Mode.insert, editor.mode);
+
+    // Type 'H'
+    try editor.handleEvent(.{ .key = Key.char('H') });
+    try std.testing.expectEqual(@as(usize, 1), editor.buffer.length());
+
+    // Escape to normal
+    try editor.handleEvent(.{ .key = .{ .code = .escape } });
+    try std.testing.expectEqual(Mode.normal, editor.mode);
+}
+
+test "cursor movement" {
+    var editor = try init(std.testing.allocator);
+    defer editor.deinit();
+
+    // Insert multi-line text
+    try editor.buffer.insertSlice(0, "Hello\nWorld\nTest");
+
+    // Start at 0,0
+    try std.testing.expectEqual(@as(usize, 0), editor.cursor_row);
+
+    // Move down
+    try editor.handleEvent(.{ .key = Key.char('j') });
+    try std.testing.expectEqual(@as(usize, 1), editor.cursor_row);
+
+    // Move right
+    try editor.handleEvent(.{ .key = Key.char('l') });
+    try std.testing.expectEqual(@as(usize, 1), editor.cursor_col);
+
+    // Move up
+    try editor.handleEvent(.{ .key = Key.char('k') });
+    try std.testing.expectEqual(@as(usize, 0), editor.cursor_row);
+}

--- a/src/Input.zig
+++ b/src/Input.zig
@@ -1,0 +1,264 @@
+const std = @import("std");
+const Terminal = @import("Terminal.zig");
+const Self = @This();
+
+// ── Key Types ─────────────────────────────────────────────────────────
+
+pub const Key = struct {
+    code: Code,
+    ctrl: bool = false,
+    alt: bool = false,
+
+    pub const Code = union(enum) {
+        char: u21,
+        // Navigation
+        up,
+        down,
+        left,
+        right,
+        home,
+        end,
+        page_up,
+        page_down,
+        // Editing
+        backspace,
+        delete,
+        tab,
+        enter,
+        escape,
+        // Function keys
+        f1,
+        f2,
+        f3,
+        f4,
+        f5,
+        f6,
+        f7,
+        f8,
+        f9,
+        f10,
+        f11,
+        f12,
+    };
+
+    pub fn char(c: u21) Key {
+        return .{ .code = .{ .char = c } };
+    }
+
+    pub fn ctrl_key(c: u21) Key {
+        return .{ .code = .{ .char = c }, .ctrl = true };
+    }
+
+    pub fn eql(a: Key, b: Key) bool {
+        return std.meta.eql(a.code, b.code) and a.ctrl == b.ctrl and a.alt == b.alt;
+    }
+};
+
+pub const Event = union(enum) {
+    key: Key,
+    resize: Terminal.Size,
+    none,
+};
+
+// ── State ─────────────────────────────────────────────────────────────
+
+term: *Terminal,
+buf: [32]u8 = undefined,
+buf_len: usize = 0,
+buf_pos: usize = 0,
+
+// ── Init ──────────────────────────────────────────────────────────────
+
+pub fn init(term: *Terminal) Self {
+    return .{ .term = term };
+}
+
+// ── Read Events ───────────────────────────────────────────────────────
+
+pub fn poll(self: *Self) !Event {
+    // Check for resize
+    if (self.term.updateSize()) {
+        return .{ .resize = .{ .rows = self.term.height, .cols = self.term.width } };
+    }
+
+    const byte = self.nextByte() orelse return .none;
+
+    // Escape sequence
+    if (byte == 0x1b) {
+        return self.parseEscape();
+    }
+
+    // Ctrl+key (0x01-0x1a except special cases)
+    if (byte < 0x20) {
+        return .{
+            .key = switch (byte) {
+                0x00 => Key{ .code = .{ .char = ' ' }, .ctrl = true }, // Ctrl+Space
+                0x08 => Key{ .code = .backspace },
+                0x09 => Key{ .code = .tab },
+                0x0a, 0x0d => Key{ .code = .enter },
+                0x1b => Key{ .code = .escape },
+                0x7f => unreachable,
+                else => Key{ .code = .{ .char = @as(u21, byte) + 0x60 }, .ctrl = true },
+            },
+        };
+    }
+
+    // DEL
+    if (byte == 0x7f) {
+        return .{ .key = .{ .code = .backspace } };
+    }
+
+    // UTF-8 multi-byte
+    if (byte >= 0x80) {
+        return .{ .key = .{ .code = .{ .char = self.decodeUtf8(byte) } } };
+    }
+
+    // Normal ASCII
+    return .{ .key = Key.char(@as(u21, byte)) };
+}
+
+// ── Escape Sequence Parser ────────────────────────────────────────────
+
+fn parseEscape(self: *Self) Event {
+    const b1 = self.peekByte() orelse return .{ .key = .{ .code = .escape } };
+
+    if (b1 == '[') {
+        _ = self.nextByte(); // consume '['
+        return self.parseCsi();
+    }
+
+    if (b1 == 'O') {
+        _ = self.nextByte(); // consume 'O'
+        const b2 = self.nextByte() orelse return .{ .key = .{ .code = .escape } };
+        return .{ .key = .{ .code = switch (b2) {
+            'P' => .f1,
+            'Q' => .f2,
+            'R' => .f3,
+            'S' => .f4,
+            'H' => .home,
+            'F' => .end,
+            else => .escape,
+        } } };
+    }
+
+    // Alt+key
+    if (b1 >= 0x20 and b1 < 0x7f) {
+        _ = self.nextByte();
+        return .{ .key = .{ .code = .{ .char = @as(u21, b1) }, .alt = true } };
+    }
+
+    return .{ .key = .{ .code = .escape } };
+}
+
+fn parseCsi(self: *Self) Event {
+    var params: [4]u16 = .{ 0, 0, 0, 0 };
+    var param_count: usize = 0;
+
+    // Parse numeric params separated by ';'
+    while (true) {
+        const b = self.peekByte() orelse break;
+        if (b >= '0' and b <= '9') {
+            _ = self.nextByte();
+            if (param_count < params.len) {
+                params[param_count] = params[param_count] * 10 + @as(u16, b - '0');
+            }
+        } else if (b == ';') {
+            _ = self.nextByte();
+            param_count += 1;
+        } else {
+            break;
+        }
+    }
+    param_count += 1;
+
+    // Final byte
+    const final = self.nextByte() orelse return .{ .key = .{ .code = .escape } };
+
+    const ctrl = param_count >= 2 and (params[1] == 5 or params[1] == 6);
+    const alt = param_count >= 2 and (params[1] == 3 or params[1] == 4);
+
+    return .{ .key = .{
+        .ctrl = ctrl,
+        .alt = alt,
+        .code = switch (final) {
+            'A' => .up,
+            'B' => .down,
+            'C' => .right,
+            'D' => .left,
+            'H' => .home,
+            'F' => .end,
+            '~' => switch (params[0]) {
+                1 => .home,
+                3 => .delete,
+                4 => .end,
+                5 => .page_up,
+                6 => .page_down,
+                15 => .f5,
+                17 => .f6,
+                18 => .f7,
+                19 => .f8,
+                20 => .f9,
+                21 => .f10,
+                23 => .f11,
+                24 => .f12,
+                else => .escape,
+            },
+            else => .escape,
+        },
+    } };
+}
+
+// ── Byte Helpers ──────────────────────────────────────────────────────
+
+fn nextByte(self: *Self) ?u8 {
+    if (self.buf_pos < self.buf_len) {
+        const b = self.buf[self.buf_pos];
+        self.buf_pos += 1;
+        return b;
+    }
+    // Read more from terminal
+    self.buf_len = self.term.readBytes(&self.buf) catch return null;
+    self.buf_pos = 0;
+    if (self.buf_len == 0) return null;
+    self.buf_pos = 1;
+    return self.buf[0];
+}
+
+fn peekByte(self: *Self) ?u8 {
+    if (self.buf_pos < self.buf_len) {
+        return self.buf[self.buf_pos];
+    }
+    self.buf_len = self.term.readBytes(&self.buf) catch return null;
+    self.buf_pos = 0;
+    if (self.buf_len == 0) return null;
+    return self.buf[0];
+}
+
+fn decodeUtf8(self: *Self, first: u8) u21 {
+    const len: u3 = std.unicode.utf8ByteSequenceLength(first) catch return 0xFFFD;
+    var bytes: [4]u8 = undefined;
+    bytes[0] = first;
+    for (1..len) |i| {
+        bytes[i] = self.nextByte() orelse return 0xFFFD;
+    }
+    return std.unicode.utf8Decode(bytes[0..len]) catch 0xFFFD;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "Key equality" {
+    const a = Key.char('a');
+    const b = Key.char('a');
+    try std.testing.expect(a.eql(b));
+
+    const c = Key.ctrl_key('c');
+    try std.testing.expect(!a.eql(c));
+}
+
+test "Key construction" {
+    const k = Key.char('x');
+    try std.testing.expect(k.code == .char);
+    try std.testing.expect(k.code.char == 'x');
+    try std.testing.expect(!k.ctrl);
+    try std.testing.expect(!k.alt);
+}

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -1,0 +1,225 @@
+const std = @import("std");
+const Terminal = @import("Terminal.zig");
+const Cell = Terminal.Cell;
+const Color = Terminal.Color;
+const Style = Terminal.Style;
+const Self = @This();
+
+// ── State ─────────────────────────────────────────────────────────────
+
+term: *Terminal,
+allocator: std.mem.Allocator,
+front: []Cell, // currently displayed
+back: []Cell, // being drawn to
+width: u16,
+height: u16,
+
+// ── Init / Deinit ─────────────────────────────────────────────────────
+
+pub fn init(allocator: std.mem.Allocator, term: *Terminal) !Self {
+    const size = @as(usize, term.width) * @as(usize, term.height);
+    const front = try allocator.alloc(Cell, size);
+    const back = try allocator.alloc(Cell, size);
+
+    @memset(front, Cell{});
+    @memset(back, Cell{});
+
+    return .{
+        .term = term,
+        .allocator = allocator,
+        .front = front,
+        .back = back,
+        .width = term.width,
+        .height = term.height,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.allocator.free(self.front);
+    self.allocator.free(self.back);
+}
+
+// ── Resize ────────────────────────────────────────────────────────────
+
+pub fn resize(self: *Self) !void {
+    const w = self.term.width;
+    const h = self.term.height;
+    if (w == self.width and h == self.height) return;
+
+    const size = @as(usize, w) * @as(usize, h);
+    self.allocator.free(self.front);
+    self.allocator.free(self.back);
+    self.front = try self.allocator.alloc(Cell, size);
+    self.back = try self.allocator.alloc(Cell, size);
+    @memset(self.front, Cell{});
+    @memset(self.back, Cell{});
+    self.width = w;
+    self.height = h;
+}
+
+// ── Drawing API ───────────────────────────────────────────────────────
+
+pub fn clear(self: *Self) void {
+    @memset(self.back, Cell{});
+}
+
+pub fn setCell(self: *Self, x: u16, y: u16, cell: Cell) void {
+    if (x >= self.width or y >= self.height) return;
+    self.back[@as(usize, y) * @as(usize, self.width) + @as(usize, x)] = cell;
+}
+
+pub fn putChar(self: *Self, x: u16, y: u16, ch: u21, fg: Color, bg: Color, style: Style) void {
+    self.setCell(x, y, .{ .char = ch, .fg = fg, .bg = bg, .style = style });
+}
+
+pub fn putStr(self: *Self, x: u16, y: u16, str: []const u8, fg: Color, bg: Color, style: Style) void {
+    var col = x;
+    var i: usize = 0;
+    while (i < str.len) {
+        if (col >= self.width) break;
+        const byte_len = std.unicode.utf8ByteSequenceLength(str[i]) catch {
+            i += 1;
+            continue;
+        };
+        if (i + byte_len > str.len) break;
+        const codepoint = std.unicode.utf8Decode(str[i .. i + byte_len]) catch {
+            i += byte_len;
+            continue;
+        };
+        self.putChar(col, y, codepoint, fg, bg, style);
+        col += 1;
+        i += byte_len;
+    }
+}
+
+pub fn putStrTrunc(self: *Self, x: u16, y: u16, str: []const u8, max_w: u16, fg: Color, bg: Color, style: Style) void {
+    var col: u16 = 0;
+    var i: usize = 0;
+    while (i < str.len and col < max_w) {
+        const byte_len = std.unicode.utf8ByteSequenceLength(str[i]) catch {
+            i += 1;
+            continue;
+        };
+        if (i + byte_len > str.len) break;
+        const codepoint = std.unicode.utf8Decode(str[i .. i + byte_len]) catch {
+            i += byte_len;
+            continue;
+        };
+        self.putChar(x + col, y, codepoint, fg, bg, style);
+        col += 1;
+        i += byte_len;
+    }
+}
+
+pub fn fillRow(self: *Self, y: u16, ch: u21, fg: Color, bg: Color, style: Style) void {
+    for (0..self.width) |x| {
+        self.putChar(@intCast(x), y, ch, fg, bg, style);
+    }
+}
+
+pub fn fillRect(self: *Self, x: u16, y: u16, w: u16, h: u16, ch: u21, fg: Color, bg: Color, style: Style) void {
+    for (0..h) |dy| {
+        for (0..w) |dx| {
+            self.putChar(x +| @as(u16, @intCast(dx)), y +| @as(u16, @intCast(dy)), ch, fg, bg, style);
+        }
+    }
+}
+
+// Box drawing
+pub fn drawBox(self: *Self, x: u16, y: u16, w: u16, h: u16, fg: Color, bg: Color) void {
+    if (w < 2 or h < 2) return;
+    // Corners
+    self.putChar(x, y, 0x250C, fg, bg, .{}); // ┌
+    self.putChar(x + w - 1, y, 0x2510, fg, bg, .{}); // ┐
+    self.putChar(x, y + h - 1, 0x2514, fg, bg, .{}); // └
+    self.putChar(x + w - 1, y + h - 1, 0x2518, fg, bg, .{}); // ┘
+    // Horizontal
+    for (1..@as(usize, w) - 1) |dx| {
+        self.putChar(x + @as(u16, @intCast(dx)), y, 0x2500, fg, bg, .{}); // ─
+        self.putChar(x + @as(u16, @intCast(dx)), y + h - 1, 0x2500, fg, bg, .{}); // ─
+    }
+    // Vertical
+    for (1..@as(usize, h) - 1) |dy| {
+        self.putChar(x, y + @as(u16, @intCast(dy)), 0x2502, fg, bg, .{}); // │
+        self.putChar(x + w - 1, y + @as(u16, @intCast(dy)), 0x2502, fg, bg, .{}); // │
+    }
+}
+
+pub fn drawVLine(self: *Self, x: u16, y: u16, h: u16, fg: Color, bg: Color) void {
+    for (0..h) |dy| {
+        self.putChar(x, y +| @as(u16, @intCast(dy)), 0x2502, fg, bg, .{});
+    }
+}
+
+// ── Flush (Diff Render) ───────────────────────────────────────────────
+
+pub fn flush(self: *Self) !void {
+    try self.term.hideCursor();
+
+    var last_fg: Color = .default;
+    var last_bg: Color = .default;
+    var last_style: Style = .{};
+    var last_row: u16 = 0xFFFF;
+    var last_col: u16 = 0xFFFF;
+
+    for (0..self.height) |y| {
+        for (0..self.width) |x| {
+            const idx = y * @as(usize, self.width) + x;
+            const back_cell = self.back[idx];
+            const front_cell = self.front[idx];
+
+            if (back_cell.eql(front_cell)) continue;
+
+            const row: u16 = @intCast(y);
+            const col: u16 = @intCast(x);
+
+            // Move cursor if not sequential
+            if (row != last_row or col != last_col) {
+                try self.term.moveCursor(row, col);
+            }
+
+            // Update style if changed
+            if (!std.meta.eql(back_cell.fg, last_fg) or
+                !std.meta.eql(back_cell.bg, last_bg) or
+                @as(u6, @bitCast(back_cell.style)) != @as(u6, @bitCast(last_style)))
+            {
+                try self.term.resetStyle();
+                try self.term.setStyle(back_cell.style);
+                try self.term.setFg(back_cell.fg);
+                try self.term.setBg(back_cell.bg);
+                last_fg = back_cell.fg;
+                last_bg = back_cell.bg;
+                last_style = back_cell.style;
+            }
+
+            try self.term.writeUtf8(back_cell.char);
+
+            last_row = row;
+            last_col = col + 1;
+        }
+    }
+
+    try self.term.resetStyle();
+
+    // Swap buffers
+    @memcpy(self.front, self.back);
+
+    try self.term.flush();
+}
+
+pub fn forceRedraw(self: *Self) void {
+    // Invalidate front buffer to force full redraw on next flush
+    @memset(self.front, Cell{ .char = 0xFFFD });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "cell operations" {
+    // Can't test flush without real terminal, but test cell logic
+    const a = Cell{ .char = 'A', .fg = .red, .bg = .default, .style = .{ .bold = true } };
+    const b = Cell{ .char = 'A', .fg = .red, .bg = .default, .style = .{ .bold = true } };
+    try std.testing.expect(a.eql(b));
+
+    const c = Cell{ .char = 'B', .fg = .red, .bg = .default, .style = .{ .bold = true } };
+    try std.testing.expect(!a.eql(c));
+}

--- a/src/Terminal.zig
+++ b/src/Terminal.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+const posix = std.posix;
+const Self = @This();
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+pub const Color = union(enum) {
+    default,
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    cyan,
+    white,
+    bright_black,
+    bright_red,
+    bright_green,
+    bright_yellow,
+    bright_blue,
+    bright_magenta,
+    bright_cyan,
+    bright_white,
+    rgb: struct { r: u8, g: u8, b: u8 },
+    fixed: u8,
+};
+
+pub const Style = packed struct {
+    bold: bool = false,
+    dim: bool = false,
+    italic: bool = false,
+    underline: bool = false,
+    reverse: bool = false,
+    strikethrough: bool = false,
+};
+
+pub const Cell = struct {
+    char: u21 = ' ',
+    fg: Color = .default,
+    bg: Color = .default,
+    style: Style = .{},
+
+    pub fn eql(a: Cell, b: Cell) bool {
+        return a.char == b.char and
+            std.meta.eql(a.fg, b.fg) and
+            std.meta.eql(a.bg, b.bg) and
+            @as(u6, @bitCast(a.style)) == @as(u6, @bitCast(b.style));
+    }
+};
+
+pub const Size = struct {
+    rows: u16,
+    cols: u16,
+};
+
+// ── State ──────────────────────────────────────────────────────────────
+
+allocator: std.mem.Allocator,
+orig_termios: posix.termios,
+tty: posix.fd_t,
+width: u16,
+height: u16,
+buf: std.ArrayList(u8),
+
+// ── Init / Deinit ─────────────────────────────────────────────────────
+
+pub fn init(allocator: std.mem.Allocator) !Self {
+    const tty = try posix.open("/dev/tty", .{ .ACCMODE = .RDWR }, 0);
+    const orig = try posix.tcgetattr(tty);
+
+    var raw = orig;
+    // Input flags
+    raw.iflag.BRKINT = false;
+    raw.iflag.ICRNL = false;
+    raw.iflag.INPCK = false;
+    raw.iflag.ISTRIP = false;
+    raw.iflag.IXON = false;
+    // Output flags
+    raw.oflag.OPOST = false;
+    // Control flags
+    raw.cflag.CSIZE = .CS8;
+    // Local flags
+    raw.lflag.ECHO = false;
+    raw.lflag.ICANON = false;
+    raw.lflag.IEXTEN = false;
+    raw.lflag.ISIG = false;
+    // Read timeout: return after 100ms with no input
+    raw.cc[@intFromEnum(posix.V.MIN)] = 0;
+    raw.cc[@intFromEnum(posix.V.TIME)] = 1;
+
+    try posix.tcsetattr(tty, .FLUSH, raw);
+
+    const size = getWindowSize(tty);
+
+    var self = Self{
+        .allocator = allocator,
+        .orig_termios = orig,
+        .tty = tty,
+        .width = size.cols,
+        .height = size.rows,
+        .buf = .{},
+    };
+
+    try self.buf.ensureTotalCapacity(allocator, 4096);
+
+    // Enter alternate screen, hide cursor
+    try self.writeStr("\x1b[?1049h");
+    try self.writeStr("\x1b[?25l");
+    try self.flush();
+
+    return self;
+}
+
+pub fn deinit(self: *Self) void {
+    // Show cursor, leave alternate screen
+    self.writeStr("\x1b[?25h") catch {};
+    self.writeStr("\x1b[?1049l") catch {};
+    self.flush() catch {};
+
+    // Restore terminal
+    posix.tcsetattr(self.tty, .FLUSH, self.orig_termios) catch {};
+    posix.close(self.tty);
+    self.buf.deinit(self.allocator);
+}
+
+// ── Window Size ───────────────────────────────────────────────────────
+
+fn getWindowSize(fd: posix.fd_t) Size {
+    var wsz: posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
+    const err = posix.system.ioctl(fd, posix.T.IOCGWINSZ, @intFromPtr(&wsz));
+    if (posix.errno(err) == .SUCCESS and wsz.col > 0 and wsz.row > 0) {
+        return .{ .rows = wsz.row, .cols = wsz.col };
+    }
+    return .{ .rows = 24, .cols = 80 };
+}
+
+pub fn updateSize(self: *Self) bool {
+    const size = getWindowSize(self.tty);
+    if (size.cols != self.width or size.rows != self.height) {
+        self.width = size.cols;
+        self.height = size.rows;
+        return true;
+    }
+    return false;
+}
+
+// ── Raw Output ────────────────────────────────────────────────────────
+
+pub fn writeStr(self: *Self, s: []const u8) !void {
+    try self.buf.appendSlice(self.allocator, s);
+}
+
+pub fn writeByte(self: *Self, b: u8) !void {
+    try self.buf.append(self.allocator, b);
+}
+
+pub fn writeFmt(self: *Self, comptime fmt: []const u8, args: anytype) !void {
+    try self.buf.writer(self.allocator).print(fmt, args);
+}
+
+pub fn flush(self: *Self) !void {
+    if (self.buf.items.len == 0) return;
+    _ = try posix.write(self.tty, self.buf.items);
+    self.buf.clearRetainingCapacity();
+}
+
+// ── Cursor Control ────────────────────────────────────────────────────
+
+pub fn moveCursor(self: *Self, row: u16, col: u16) !void {
+    try self.writeFmt("\x1b[{};{}H", .{ row + 1, col + 1 });
+}
+
+pub fn showCursor(self: *Self) !void {
+    try self.writeStr("\x1b[?25h");
+}
+
+pub fn hideCursor(self: *Self) !void {
+    try self.writeStr("\x1b[?25l");
+}
+
+// ── Screen Control ────────────────────────────────────────────────────
+
+pub fn clearScreen(self: *Self) !void {
+    try self.writeStr("\x1b[2J");
+    try self.writeStr("\x1b[H");
+}
+
+pub fn clearLine(self: *Self) !void {
+    try self.writeStr("\x1b[2K");
+}
+
+pub fn clearToEol(self: *Self) !void {
+    try self.writeStr("\x1b[K");
+}
+
+// ── Style / Color ─────────────────────────────────────────────────────
+
+pub fn resetStyle(self: *Self) !void {
+    try self.writeStr("\x1b[0m");
+}
+
+pub fn setStyle(self: *Self, style: Style) !void {
+    if (style.bold) try self.writeStr("\x1b[1m");
+    if (style.dim) try self.writeStr("\x1b[2m");
+    if (style.italic) try self.writeStr("\x1b[3m");
+    if (style.underline) try self.writeStr("\x1b[4m");
+    if (style.reverse) try self.writeStr("\x1b[7m");
+    if (style.strikethrough) try self.writeStr("\x1b[9m");
+}
+
+pub fn setFg(self: *Self, color: Color) !void {
+    switch (color) {
+        .default => try self.writeStr("\x1b[39m"),
+        .black => try self.writeStr("\x1b[30m"),
+        .red => try self.writeStr("\x1b[31m"),
+        .green => try self.writeStr("\x1b[32m"),
+        .yellow => try self.writeStr("\x1b[33m"),
+        .blue => try self.writeStr("\x1b[34m"),
+        .magenta => try self.writeStr("\x1b[35m"),
+        .cyan => try self.writeStr("\x1b[36m"),
+        .white => try self.writeStr("\x1b[37m"),
+        .bright_black => try self.writeStr("\x1b[90m"),
+        .bright_red => try self.writeStr("\x1b[91m"),
+        .bright_green => try self.writeStr("\x1b[92m"),
+        .bright_yellow => try self.writeStr("\x1b[93m"),
+        .bright_blue => try self.writeStr("\x1b[94m"),
+        .bright_magenta => try self.writeStr("\x1b[95m"),
+        .bright_cyan => try self.writeStr("\x1b[96m"),
+        .bright_white => try self.writeStr("\x1b[97m"),
+        .rgb => |c| try self.writeFmt("\x1b[38;2;{};{};{}m", .{ c.r, c.g, c.b }),
+        .fixed => |n| try self.writeFmt("\x1b[38;5;{}m", .{n}),
+    }
+}
+
+pub fn setBg(self: *Self, color: Color) !void {
+    switch (color) {
+        .default => try self.writeStr("\x1b[49m"),
+        .black => try self.writeStr("\x1b[40m"),
+        .red => try self.writeStr("\x1b[41m"),
+        .green => try self.writeStr("\x1b[42m"),
+        .yellow => try self.writeStr("\x1b[43m"),
+        .blue => try self.writeStr("\x1b[44m"),
+        .magenta => try self.writeStr("\x1b[45m"),
+        .cyan => try self.writeStr("\x1b[46m"),
+        .white => try self.writeStr("\x1b[47m"),
+        .bright_black => try self.writeStr("\x1b[100m"),
+        .bright_red => try self.writeStr("\x1b[101m"),
+        .bright_green => try self.writeStr("\x1b[102m"),
+        .bright_yellow => try self.writeStr("\x1b[103m"),
+        .bright_blue => try self.writeStr("\x1b[104m"),
+        .bright_magenta => try self.writeStr("\x1b[105m"),
+        .bright_cyan => try self.writeStr("\x1b[106m"),
+        .bright_white => try self.writeStr("\x1b[107m"),
+        .rgb => |c| try self.writeFmt("\x1b[48;2;{};{};{}m", .{ c.r, c.g, c.b }),
+        .fixed => |n| try self.writeFmt("\x1b[48;5;{}m", .{n}),
+    }
+}
+
+pub fn setCell(self: *Self, style: Style, fg: Color, bg: Color) !void {
+    try self.resetStyle();
+    try self.setStyle(style);
+    try self.setFg(fg);
+    try self.setBg(bg);
+}
+
+// ── Read Input ────────────────────────────────────────────────────────
+
+pub fn readByte(self: *Self) !?u8 {
+    var buf_local: [1]u8 = undefined;
+    const n = posix.read(self.tty, &buf_local) catch |err| switch (err) {
+        error.WouldBlock => return null,
+        else => return err,
+    };
+    if (n == 0) return null;
+    return buf_local[0];
+}
+
+pub fn readBytes(self: *Self, out: []u8) !usize {
+    return posix.read(self.tty, out) catch |err| switch (err) {
+        error.WouldBlock => return 0,
+        else => return err,
+    };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+pub fn writeUtf8(self: *Self, codepoint: u21) !void {
+    var buf_local: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(codepoint, &buf_local) catch return;
+    try self.writeStr(buf_local[0..len]);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "Cell equality" {
+    const a = Cell{};
+    const b = Cell{};
+    try std.testing.expect(a.eql(b));
+
+    const c = Cell{ .char = 'X', .fg = .red };
+    try std.testing.expect(!a.eql(c));
+}
+
+test "Style bitcast" {
+    const s = Style{ .bold = true, .italic = true };
+    const bits: u6 = @bitCast(s);
+    try std.testing.expect(bits != 0);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const Terminal = @import("Terminal.zig");
+const Input = @import("Input.zig");
+const Buffer = @import("Buffer.zig");
+const Editor = @import("Editor.zig");
+const Renderer = @import("Renderer.zig");
+const Layout = @import("ui/Layout.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Parse CLI args
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var file_path: ?[]const u8 = null;
+    if (args.len > 1) {
+        file_path = args[1];
+    }
+
+    // Initialize terminal
+    var term = try Terminal.init(allocator);
+    defer term.deinit();
+
+    // Initialize subsystems
+    var input = Input.init(&term);
+    var renderer = try Renderer.init(allocator, &term);
+    defer renderer.deinit();
+    var editor = try Editor.init(allocator);
+    defer editor.deinit();
+    var layout = Layout{};
+
+    // Open file if provided
+    if (file_path) |path| {
+        editor.openFile(path) catch {
+            editor.status.set("New file", false);
+            const owned = try allocator.dupe(u8, path);
+            editor.file_path_owned = owned;
+            editor.file_path = owned;
+        };
+    }
+
+    // Scan working directory for file tree
+    var file_entries: std.ArrayList(Layout.FileEntry) = .{};
+    defer {
+        for (file_entries.items) |entry| allocator.free(entry.name);
+        file_entries.deinit(allocator);
+    }
+    try scanDirectory(allocator, ".", &file_entries);
+
+    // Main loop
+    while (!editor.should_quit) {
+        // Check for resize
+        if (term.updateSize()) {
+            try renderer.resize();
+            renderer.forceRedraw();
+        }
+
+        // Compute layout
+        layout.compute(term.width, term.height);
+
+        // Update editor viewport
+        editor.view_x = layout.editor_rect.x;
+        editor.view_y = layout.editor_rect.y;
+        editor.view_width = layout.editor_rect.w;
+        editor.view_height = layout.editor_rect.h;
+
+        // Draw
+        renderer.clear();
+        layout.renderChrome(&renderer);
+        layout.renderFileTree(&renderer, file_entries.items);
+        try editor.render(&renderer);
+        editor.renderStatusBar(&renderer, layout.status_rect.y);
+        editor.renderCommandBar(&renderer, layout.cmd_rect.y);
+        layout.renderPreview(&renderer, &editor);
+
+        try renderer.flush();
+
+        // Handle input
+        const event = try input.poll();
+        switch (event) {
+            .key => |key| {
+                // Global shortcuts
+                if (key.code == .tab and !key.ctrl and editor.mode == .normal) {
+                    layout.cyclePanel();
+                    continue;
+                }
+                if (key.code == .char and editor.mode == .normal) {
+                    switch (key.code.char) {
+                        '1' => if (key.alt) {
+                            layout.togglePanel(.file_tree);
+                            layout.compute(term.width, term.height);
+                            renderer.forceRedraw();
+                            continue;
+                        },
+                        '2' => if (key.alt) {
+                            layout.togglePanel(.preview);
+                            layout.compute(term.width, term.height);
+                            renderer.forceRedraw();
+                            continue;
+                        },
+                        else => {},
+                    }
+                }
+                try editor.handleEvent(event);
+            },
+            .resize => {
+                try renderer.resize();
+                renderer.forceRedraw();
+            },
+            .none => {},
+        }
+    }
+}
+
+fn scanDirectory(allocator: std.mem.Allocator, path: []const u8, entries: *std.ArrayList(Layout.FileEntry)) !void {
+    var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.name[0] == '.') continue; // skip hidden
+        const name = try allocator.dupe(u8, entry.name);
+        const is_md = std.mem.endsWith(u8, entry.name, ".md") or
+            std.mem.endsWith(u8, entry.name, ".rndm");
+        try entries.append(allocator, .{
+            .name = name,
+            .is_dir = entry.kind == .directory,
+            .is_md = is_md,
+        });
+    }
+
+    // Sort: dirs first, then alphabetical
+    std.mem.sort(Layout.FileEntry, entries.items, {}, struct {
+        fn lessThan(_: void, a: Layout.FileEntry, b: Layout.FileEntry) bool {
+            if (a.is_dir != b.is_dir) return a.is_dir;
+            return std.mem.order(u8, a.name, b.name) == .lt;
+        }
+    }.lessThan);
+}
+
+// Pull in all tests from submodules
+test {
+    _ = @import("Terminal.zig");
+    _ = @import("Input.zig");
+    _ = @import("Buffer.zig");
+    _ = @import("Editor.zig");
+    _ = @import("Renderer.zig");
+    _ = @import("markdown/syntax.zig");
+    _ = @import("ui/Layout.zig");
+}

--- a/src/markdown/syntax.zig
+++ b/src/markdown/syntax.zig
@@ -1,0 +1,389 @@
+const std = @import("std");
+const Terminal = @import("../Terminal.zig");
+
+pub const TokenType = enum {
+    normal,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    bold,
+    italic,
+    bold_italic,
+    code_inline,
+    code_block_marker,
+    code_block,
+    link_text,
+    link_url,
+    image_marker,
+    list_bullet,
+    list_number,
+    blockquote,
+    hr,
+    strikethrough,
+    task_checkbox,
+    html_tag,
+};
+
+pub const Span = struct {
+    start: usize,
+    end: usize,
+    token: TokenType,
+};
+
+pub const Theme = struct {
+    pub fn getFg(token: TokenType) Terminal.Color {
+        return switch (token) {
+            .h1 => .bright_cyan,
+            .h2 => .bright_green,
+            .h3 => .bright_yellow,
+            .h4 => .bright_blue,
+            .h5 => .bright_magenta,
+            .h6 => .cyan,
+            .bold, .bold_italic => .bright_white,
+            .italic => .white,
+            .code_inline, .code_block, .code_block_marker => .yellow,
+            .link_text => .bright_blue,
+            .link_url => .blue,
+            .image_marker => .bright_magenta,
+            .list_bullet, .list_number => .bright_magenta,
+            .blockquote => .bright_black,
+            .hr => .bright_black,
+            .strikethrough => .bright_black,
+            .task_checkbox => .bright_yellow,
+            .html_tag => .bright_black,
+            .normal => .default,
+        };
+    }
+
+    pub fn getStyle(token: TokenType) Terminal.Style {
+        return switch (token) {
+            .h1 => .{ .bold = true },
+            .h2 => .{ .bold = true },
+            .h3 => .{ .bold = true },
+            .bold => .{ .bold = true },
+            .italic => .{ .italic = true },
+            .bold_italic => .{ .bold = true, .italic = true },
+            .code_inline, .code_block, .code_block_marker => .{},
+            .link_text => .{ .underline = true },
+            .link_url => .{ .dim = true },
+            .strikethrough => .{ .strikethrough = true },
+            .blockquote => .{ .italic = true },
+            .hr => .{ .dim = true },
+            else => .{},
+        };
+    }
+
+    pub fn getBg(token: TokenType) Terminal.Color {
+        return switch (token) {
+            .code_inline => .{ .fixed = 236 },
+            .code_block => .{ .fixed = 235 },
+            .code_block_marker => .{ .fixed = 235 },
+            else => .default,
+        };
+    }
+};
+
+pub const LineContext = struct {
+    in_code_block: bool = false,
+};
+
+pub fn isCodeFence(line: []const u8) bool {
+    const trimmed = std.mem.trimLeft(u8, line, " ");
+    if (trimmed.len < 3) return false;
+    if (std.mem.startsWith(u8, trimmed, "```")) return true;
+    if (std.mem.startsWith(u8, trimmed, "~~~")) return true;
+    return false;
+}
+
+pub fn tokenizeLine(allocator: std.mem.Allocator, line: []const u8, ctx: *LineContext, spans: *std.ArrayList(Span)) !void {
+    spans.clearRetainingCapacity();
+
+    if (isCodeFence(line)) {
+        try spans.append(allocator, .{ .start = 0, .end = line.len, .token = .code_block_marker });
+        ctx.in_code_block = !ctx.in_code_block;
+        return;
+    }
+
+    if (ctx.in_code_block) {
+        try spans.append(allocator, .{ .start = 0, .end = line.len, .token = .code_block });
+        return;
+    }
+
+    if (line.len == 0) return;
+
+    const trimmed = std.mem.trimLeft(u8, line, " \t");
+
+    if (isHorizontalRule(trimmed)) {
+        try spans.append(allocator, .{ .start = 0, .end = line.len, .token = .hr });
+        return;
+    }
+
+    if (parseHeader(trimmed)) |level| {
+        const token: TokenType = switch (level) {
+            1 => .h1,
+            2 => .h2,
+            3 => .h3,
+            4 => .h4,
+            5 => .h5,
+            6 => .h6,
+            else => .normal,
+        };
+        try spans.append(allocator, .{ .start = 0, .end = line.len, .token = token });
+        return;
+    }
+
+    if (trimmed.len > 0 and trimmed[0] == '>') {
+        try spans.append(allocator, .{ .start = 0, .end = line.len, .token = .blockquote });
+        return;
+    }
+
+    if (isListItem(trimmed)) {
+        const indent = line.len - trimmed.len;
+        const bullet_end = indent + 2;
+        try spans.append(allocator, .{ .start = 0, .end = bullet_end, .token = .list_bullet });
+        if (bullet_end < line.len) {
+            try tokenizeInline(allocator, line, bullet_end, line.len, spans);
+        }
+        return;
+    }
+
+    if (isNumberedList(trimmed)) {
+        const indent = line.len - trimmed.len;
+        const num_end = indent + numberedListPrefixLen(trimmed);
+        try spans.append(allocator, .{ .start = 0, .end = num_end, .token = .list_number });
+        if (num_end < line.len) {
+            try tokenizeInline(allocator, line, num_end, line.len, spans);
+        }
+        return;
+    }
+
+    try tokenizeInline(allocator, line, 0, line.len, spans);
+}
+
+fn tokenizeInline(allocator: std.mem.Allocator, line: []const u8, start: usize, end: usize, spans: *std.ArrayList(Span)) !void {
+    var i = start;
+    var text_start = start;
+
+    while (i < end) {
+        if (line[i] == '`') {
+            if (i > text_start) {
+                try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+            }
+            const code_end = findInlineCode(line, i, end);
+            try spans.append(allocator, .{ .start = i, .end = code_end, .token = .code_inline });
+            i = code_end;
+            text_start = i;
+            continue;
+        }
+
+        // Bold + italic
+        if (i + 2 < end and ((line[i] == '*' and line[i + 1] == '*' and line[i + 2] == '*') or
+            (line[i] == '_' and line[i + 1] == '_' and line[i + 2] == '_')))
+        {
+            const marker = line[i];
+            if (findClosing(line, i + 3, end, &[3]u8{ marker, marker, marker })) |close| {
+                if (i > text_start) try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+                try spans.append(allocator, .{ .start = i, .end = close + 3, .token = .bold_italic });
+                i = close + 3;
+                text_start = i;
+                continue;
+            }
+        }
+
+        // Bold
+        if (i + 1 < end and ((line[i] == '*' and line[i + 1] == '*') or
+            (line[i] == '_' and line[i + 1] == '_')))
+        {
+            const marker = line[i];
+            if (findClosing(line, i + 2, end, &[2]u8{ marker, marker })) |close| {
+                if (i > text_start) try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+                try spans.append(allocator, .{ .start = i, .end = close + 2, .token = .bold });
+                i = close + 2;
+                text_start = i;
+                continue;
+            }
+        }
+
+        // Italic
+        if (line[i] == '*' or line[i] == '_') {
+            const marker = line[i];
+            if (findClosing(line, i + 1, end, &[1]u8{marker})) |close| {
+                if (close > i + 1) {
+                    if (i > text_start) try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+                    try spans.append(allocator, .{ .start = i, .end = close + 1, .token = .italic });
+                    i = close + 1;
+                    text_start = i;
+                    continue;
+                }
+            }
+        }
+
+        // Strikethrough
+        if (i + 1 < end and line[i] == '~' and line[i + 1] == '~') {
+            if (findClosing(line, i + 2, end, "~~")) |close| {
+                if (i > text_start) try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+                try spans.append(allocator, .{ .start = i, .end = close + 2, .token = .strikethrough });
+                i = close + 2;
+                text_start = i;
+                continue;
+            }
+        }
+
+        // Links
+        if (line[i] == '[') {
+            if (parseLink(line, i, end)) |link| {
+                if (i > text_start) try spans.append(allocator, .{ .start = text_start, .end = i, .token = .normal });
+                try spans.append(allocator, .{ .start = i, .end = link.text_end, .token = .link_text });
+                try spans.append(allocator, .{ .start = link.text_end, .end = link.url_end, .token = .link_url });
+                i = link.url_end;
+                text_start = i;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    if (text_start < end) {
+        try spans.append(allocator, .{ .start = text_start, .end = end, .token = .normal });
+    }
+}
+
+fn parseHeader(line: []const u8) ?u8 {
+    var level: u8 = 0;
+    for (line) |c| {
+        if (c == '#') {
+            level += 1;
+            if (level > 6) return null;
+        } else if (c == ' ') {
+            if (level >= 1) return level;
+            return null;
+        } else {
+            return null;
+        }
+    }
+    return null;
+}
+
+fn isHorizontalRule(line: []const u8) bool {
+    if (line.len < 3) return false;
+    var count: usize = 0;
+    const ch = line[0];
+    if (ch != '-' and ch != '*' and ch != '_') return false;
+    for (line) |c| {
+        if (c == ch) count += 1 else if (c != ' ') return false;
+    }
+    return count >= 3;
+}
+
+fn isListItem(line: []const u8) bool {
+    if (line.len < 2) return false;
+    return (line[0] == '-' or line[0] == '*' or line[0] == '+') and line[1] == ' ';
+}
+
+fn isNumberedList(line: []const u8) bool {
+    var i: usize = 0;
+    while (i < line.len and line[i] >= '0' and line[i] <= '9') : (i += 1) {}
+    if (i == 0 or i >= line.len) return false;
+    return line[i] == '.' and i + 1 < line.len and line[i + 1] == ' ';
+}
+
+fn numberedListPrefixLen(line: []const u8) usize {
+    var i: usize = 0;
+    while (i < line.len and line[i] >= '0' and line[i] <= '9') : (i += 1) {}
+    return i + 2;
+}
+
+fn findInlineCode(line: []const u8, start: usize, end: usize) usize {
+    var i = start + 1;
+    while (i < end) : (i += 1) {
+        if (line[i] == '`') return i + 1;
+    }
+    return end;
+}
+
+fn findClosing(line: []const u8, start: usize, end: usize, marker: []const u8) ?usize {
+    if (start + marker.len > end) return null;
+    var i = start;
+    while (i + marker.len <= end) : (i += 1) {
+        if (std.mem.eql(u8, line[i .. i + marker.len], marker)) return i;
+    }
+    return null;
+}
+
+const LinkResult = struct { text_end: usize, url_end: usize };
+
+fn parseLink(line: []const u8, start: usize, end: usize) ?LinkResult {
+    var i = start + 1;
+    while (i < end) : (i += 1) {
+        if (line[i] == ']') break;
+    } else return null;
+    if (i >= end) return null;
+    const bracket_close = i;
+    if (bracket_close + 1 >= end or line[bracket_close + 1] != '(') return null;
+    i = bracket_close + 2;
+    while (i < end) : (i += 1) {
+        if (line[i] == ')') {
+            return .{ .text_end = bracket_close + 1, .url_end = i + 1 };
+        }
+    }
+    return null;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "header detection" {
+    try std.testing.expectEqual(@as(?u8, 1), parseHeader("# Hello"));
+    try std.testing.expectEqual(@as(?u8, 3), parseHeader("### Test"));
+    try std.testing.expectEqual(@as(?u8, null), parseHeader("####### Too many"));
+    try std.testing.expectEqual(@as(?u8, null), parseHeader("Not a header"));
+}
+
+test "horizontal rule" {
+    try std.testing.expect(isHorizontalRule("---"));
+    try std.testing.expect(isHorizontalRule("***"));
+    try std.testing.expect(isHorizontalRule("___"));
+    try std.testing.expect(isHorizontalRule("- - -"));
+    try std.testing.expect(!isHorizontalRule("--"));
+    try std.testing.expect(!isHorizontalRule("abc"));
+}
+
+test "code fence" {
+    try std.testing.expect(isCodeFence("```"));
+    try std.testing.expect(isCodeFence("```zig"));
+    try std.testing.expect(isCodeFence("~~~"));
+    try std.testing.expect(!isCodeFence("``"));
+}
+
+test "tokenize header line" {
+    const allocator = std.testing.allocator;
+    var spans: std.ArrayList(Span) = .{};
+    defer spans.deinit(allocator);
+    var ctx = LineContext{};
+
+    try tokenizeLine(allocator, "## Hello world", &ctx, &spans);
+    try std.testing.expectEqual(@as(usize, 1), spans.items.len);
+    try std.testing.expectEqual(TokenType.h2, spans.items[0].token);
+}
+
+test "tokenize code block" {
+    const allocator = std.testing.allocator;
+    var spans: std.ArrayList(Span) = .{};
+    defer spans.deinit(allocator);
+    var ctx = LineContext{};
+
+    try tokenizeLine(allocator, "```zig", &ctx, &spans);
+    try std.testing.expect(ctx.in_code_block);
+    try std.testing.expectEqual(TokenType.code_block_marker, spans.items[0].token);
+
+    spans.clearRetainingCapacity();
+    try tokenizeLine(allocator, "const x = 5;", &ctx, &spans);
+    try std.testing.expectEqual(TokenType.code_block, spans.items[0].token);
+
+    spans.clearRetainingCapacity();
+    try tokenizeLine(allocator, "```", &ctx, &spans);
+    try std.testing.expect(!ctx.in_code_block);
+}

--- a/src/ui/Layout.zig
+++ b/src/ui/Layout.zig
@@ -1,0 +1,193 @@
+const std = @import("std");
+const Renderer = @import("../Renderer.zig");
+const Terminal = @import("../Terminal.zig");
+const Editor = @import("../Editor.zig");
+const Self = @This();
+
+pub const Panel = enum {
+    file_tree,
+    editor,
+    preview,
+};
+
+pub const Rect = struct {
+    x: u16,
+    y: u16,
+    w: u16,
+    h: u16,
+};
+
+// ── State ─────────────────────────────────────────────────────────────
+
+show_file_tree: bool = true,
+show_preview: bool = true,
+active_panel: Panel = .editor,
+// Computed rects
+title_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+tree_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+editor_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+preview_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+status_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+cmd_rect: Rect = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
+width: u16 = 0,
+height: u16 = 0,
+
+// ── Layout Calculation ────────────────────────────────────────────────
+
+pub fn compute(self: *Self, w: u16, h: u16) void {
+    self.width = w;
+    self.height = h;
+
+    // Reserve: 1 row title, 1 row status, 1 row command
+    const chrome_rows: u16 = 3;
+    const content_h = if (h > chrome_rows) h - chrome_rows else 1;
+    const content_y: u16 = 1; // after title
+
+    self.title_rect = .{ .x = 0, .y = 0, .w = w, .h = 1 };
+    self.status_rect = .{ .x = 0, .y = h -| 2, .w = w, .h = 1 };
+    self.cmd_rect = .{ .x = 0, .y = h -| 1, .w = w, .h = 1 };
+
+    // Panel widths
+    const tree_w: u16 = if (self.show_file_tree) @min(w / 5, 30) else 0;
+    const preview_w: u16 = if (self.show_preview) @min(w / 4, 40) else 0;
+    const editor_w = w -| tree_w -| preview_w;
+
+    if (self.show_file_tree) {
+        self.tree_rect = .{ .x = 0, .y = content_y, .w = tree_w, .h = content_h };
+    }
+
+    self.editor_rect = .{ .x = tree_w, .y = content_y, .w = editor_w, .h = content_h };
+
+    if (self.show_preview) {
+        self.preview_rect = .{ .x = tree_w + editor_w, .y = content_y, .w = preview_w, .h = content_h };
+    }
+}
+
+pub fn togglePanel(self: *Self, panel: Panel) void {
+    switch (panel) {
+        .file_tree => self.show_file_tree = !self.show_file_tree,
+        .preview => self.show_preview = !self.show_preview,
+        .editor => {},
+    }
+}
+
+pub fn cyclePanel(self: *Self) void {
+    self.active_panel = switch (self.active_panel) {
+        .file_tree => .editor,
+        .editor => if (self.show_preview) .preview else .file_tree,
+        .preview => if (self.show_file_tree) .file_tree else .editor,
+    };
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────
+
+pub fn renderChrome(self: *Self, renderer: *Renderer) void {
+    // Title bar
+    renderer.fillRow(self.title_rect.y, ' ', .bright_white, .blue, .{});
+    const title = " lazy-md v0.1.0";
+    renderer.putStr(0, 0, title, .bright_white, .blue, .{ .bold = true });
+
+    // Keyboard hints on title bar (right-aligned)
+    const hints = "Tab:panels  1:tree  2:preview  :q quit ";
+    if (hints.len < self.width) {
+        renderer.putStr(self.width -| @as(u16, @intCast(hints.len)), 0, hints, .bright_cyan, .blue, .{});
+    }
+
+    // Panel borders
+    if (self.show_file_tree and self.tree_rect.w > 0) {
+        renderer.drawVLine(self.tree_rect.x + self.tree_rect.w -| 1, self.tree_rect.y, self.tree_rect.h, .bright_black, .default);
+    }
+    if (self.show_preview and self.preview_rect.w > 0) {
+        renderer.drawVLine(self.preview_rect.x, self.preview_rect.y, self.preview_rect.h, .bright_black, .default);
+    }
+}
+
+pub fn renderFileTree(self: *Self, renderer: *Renderer, entries: []const FileEntry) void {
+    if (!self.show_file_tree) return;
+
+    const r = self.tree_rect;
+    const is_active = self.active_panel == .file_tree;
+    const border_fg: Terminal.Color = if (is_active) .bright_cyan else .bright_black;
+
+    // Panel header
+    renderer.putStr(r.x + 1, r.y, " Files ", .bright_white, .default, .{ .bold = true });
+    renderer.drawVLine(r.x + r.w -| 1, r.y, r.h, border_fg, .default);
+
+    // File entries
+    const max_entries = if (r.h > 2) r.h - 1 else 0;
+    for (entries, 0..) |entry, i| {
+        if (i >= max_entries) break;
+        const y = r.y + 1 + @as(u16, @intCast(i));
+        const icon: []const u8 = if (entry.is_dir) "  " else "  ";
+        const fg: Terminal.Color = if (entry.is_dir) .bright_blue else if (entry.is_md) .bright_green else .white;
+        renderer.putStrTrunc(r.x + 1, y, icon, r.w -| 2, fg, .default, .{});
+        renderer.putStrTrunc(r.x + 3, y, entry.name, r.w -| 4, fg, .default, .{});
+    }
+}
+
+pub fn renderPreview(self: *Self, renderer: *Renderer, editor: *Editor) void {
+    if (!self.show_preview) return;
+
+    const r = self.preview_rect;
+    const is_active = self.active_panel == .preview;
+    const border_fg: Terminal.Color = if (is_active) .bright_cyan else .bright_black;
+
+    // Panel border and header
+    renderer.drawVLine(r.x, r.y, r.h, border_fg, .default);
+    renderer.putStr(r.x + 1, r.y, " Preview ", .bright_white, .default, .{ .bold = true });
+
+    // Simple preview: render markdown with basic formatting hints
+    const content_x = r.x + 2;
+    const content_w = if (r.w > 3) r.w - 3 else 1;
+
+    var preview_ctx: @import("../markdown/syntax.zig").LineContext = .{};
+    var spans: std.ArrayList(@import("../markdown/syntax.zig").Span) = .{};
+    defer spans.deinit(editor.allocator);
+
+    for (0..r.h -| 1) |screen_row| {
+        const buf_row = editor.scroll_row + screen_row;
+        if (buf_row >= editor.buffer.lineCount()) break;
+        const y = r.y + 1 + @as(u16, @intCast(screen_row));
+        const line = editor.buffer.getLine(buf_row);
+
+        @import("../markdown/syntax.zig").tokenizeLine(editor.allocator, line, &preview_ctx, &spans) catch continue;
+
+        if (spans.items.len == 0) continue;
+
+        // Render based on primary token
+        const primary = spans.items[0].token;
+        const fg = @import("../markdown/syntax.zig").Theme.getFg(primary);
+        const style = @import("../markdown/syntax.zig").Theme.getStyle(primary);
+
+        renderer.putStrTrunc(content_x, y, line, content_w, fg, .default, style);
+    }
+}
+
+pub const FileEntry = struct {
+    name: []const u8,
+    is_dir: bool,
+    is_md: bool,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+test "layout computation" {
+    var layout = Self{};
+    layout.compute(120, 40);
+
+    try std.testing.expect(layout.editor_rect.w > 0);
+    try std.testing.expect(layout.tree_rect.w > 0);
+    try std.testing.expect(layout.preview_rect.w > 0);
+    try std.testing.expectEqual(@as(u16, 0), layout.title_rect.y);
+}
+
+test "toggle panels" {
+    var layout = Self{};
+    layout.compute(120, 40);
+
+    const old_tree_w = layout.tree_rect.w;
+    layout.togglePanel(.file_tree);
+    layout.compute(120, 40);
+    try std.testing.expect(!layout.show_file_tree);
+    _ = old_tree_w;
+}

--- a/story.md
+++ b/story.md
@@ -1,0 +1,1 @@
+Built with power of caffeine from tonico with cafebabes

--- a/todoes.md
+++ b/todoes.md
@@ -1,0 +1,14 @@
+* we need to plan the project
+* we need to design the project
+* we need to implement the project
+* we need to test the project
+* we need to deploy the project
+* we need to document the project
+* we need to review the project
+* we need to launch the project
+* we need to maintain the project
+* we need to update the project
+* we need to keep the loop on 
+* we need to iterate the loop
+* we need to iterate the loop again
+* we need to iterate the loop again and again ...


### PR DESCRIPTION
## Summary

- Zero-dependency terminal markdown editor built on POSIX termios + ANSI escape codes
- Vim-like modal editing (Normal/Insert/Command) with familiar keybindings (hjkl, w/b/e, dd, undo/redo)
- lazygit-style 3-panel layout: file tree, syntax-highlighted editor, markdown preview
- Gap buffer data structure with undo/redo stack, double-buffered diff renderer
- Markdown tokenizer for headers, bold, italic, code blocks, links, lists, blockquotes, strikethrough
- 19 tests passing, Zig 0.15.1, ~2700 lines across 8 source files

## Test plan

- [x] `zig build` compiles cleanly with zero warnings
- [x] `zig build test` passes all 19 tests (Buffer, Input, Editor, Syntax, Layout, Renderer)
- [ ] `zig build run -- README.md` opens file with syntax highlighting and vim navigation
- [ ] Panel toggling with Tab/Alt+1/Alt+2 works
- [ ] `:w` `:q` `:wq` commands work correctly
- [ ] Undo/redo (`u`/`Ctrl+R`) works across edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)