### PR TITLE
Fix dark mode mobile hamburger menu

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -34,6 +34,14 @@
   border-bottom: 1px solid #30363d;
 }
 
+[data-theme='dark'] .navbar-sidebar {
+  background-color: #0d1117;
+}
+
+[data-theme='dark'] .navbar-sidebar__backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
 [data-theme='dark'] .footer--dark {
   --ifm-footer-background-color: #0d1117;
   border-top: 1px solid #30363d;


### PR DESCRIPTION
## Summary
- Fix broken hamburger menu rendering in dark mode on mobile
- Add solid background color (`#0d1117`) to `.navbar-sidebar` in dark mode instead of inheriting the semi-transparent navbar background
- Add proper backdrop overlay for the mobile sidebar

## Test plan
- [ ] Open the website on mobile (or resize browser to mobile width)
- [ ] Switch to dark mode
- [ ] Tap the hamburger menu icon
- [ ] Verify the sidebar has a solid dark background and is fully readable
- [ ] Verify light mode hamburger menu still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)