### PR TITLE
Add install guides and one-liner scripts for Linux, macOS, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,35 @@ A terminal-based markdown editor written in Zig. Inspired by [lazygit](https://g
 
 ## Install
 
-Requires [Zig](https://ziglang.org/download/) 0.15.1+.
+**Linux:**
 
 ```bash
-git clone https://github.com/user/lazy-md.git
-cd lazy-md
+curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-linux.sh | bash
+```
+
+**macOS:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-macos.sh | bash
+```
+
+**Windows** (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-windows.ps1 | iex
+```
+
+**From source** (all platforms — requires [Zig](https://ziglang.org/download/) 0.15.1+):
+
+```bash
+git clone https://github.com/EME130/lazymd.git
+cd lazymd
 zig build
+cp zig-out/bin/lazy-md /usr/local/bin/   # or add to your PATH
 ```
 
-The binary is at `zig-out/bin/lazy-md`. Optionally copy it to your PATH:
-
-```bash
-cp zig-out/bin/lazy-md /usr/local/bin/
-```
-
-Pre-built binaries for Linux and macOS are available on the [Releases](https://github.com/user/lazy-md/releases) page.
+Pre-built binaries are available on the [Releases](https://github.com/EME130/lazymd/releases) page.
+See detailed guides: [Linux](docs/install-linux.md) | [macOS](docs/install-macos.md) | [Windows](docs/install-windows.md)
 
 ## Quick Start
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -1,0 +1,98 @@
+# Installing lazy-md on Linux
+
+## One-liner
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-linux.sh | bash
+```
+
+This downloads the latest pre-built binary and installs it to `/usr/local/bin`.
+
+To install to a custom directory:
+
+```bash
+INSTALL_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-linux.sh | bash
+```
+
+## Manual install (pre-built binary)
+
+1. Go to the [Releases](https://github.com/EME130/lazymd/releases) page
+2. Download the tarball for your architecture:
+   - `lazy-md-linux-x86_64.tar.gz` for Intel/AMD 64-bit
+   - `lazy-md-linux-aarch64.tar.gz` for ARM 64-bit
+3. Extract and install:
+
+```bash
+tar -xzf lazy-md-linux-x86_64.tar.gz
+sudo cp lazy-md /usr/local/bin/
+```
+
+## Build from source
+
+### Prerequisites
+
+Install Zig 0.15.1 or later:
+
+```bash
+# Option 1: From ziglang.org
+# Download from https://ziglang.org/download/ and extract to your PATH
+
+# Option 2: Using snap
+sudo snap install zig --classic --beta
+
+# Option 3: Using your package manager (if available)
+# Arch Linux
+sudo pacman -S zig
+
+# Fedora (via COPR)
+sudo dnf copr enable sentry/zig
+sudo dnf install zig
+```
+
+Verify the installation:
+
+```bash
+zig version
+# Should output 0.15.1 or later
+```
+
+### Build
+
+```bash
+git clone https://github.com/EME130/lazymd.git
+cd lazymd
+zig build
+```
+
+The binary is at `zig-out/bin/lazy-md`. Copy it to your PATH:
+
+```bash
+sudo cp zig-out/bin/lazy-md /usr/local/bin/
+```
+
+Or install to your local bin:
+
+```bash
+mkdir -p ~/.local/bin
+cp zig-out/bin/lazy-md ~/.local/bin/
+```
+
+Make sure `~/.local/bin` is in your `PATH` (add to `~/.bashrc` or `~/.zshrc`):
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Verify
+
+```bash
+lazy-md --version
+```
+
+## Uninstall
+
+```bash
+sudo rm /usr/local/bin/lazy-md
+# or
+rm ~/.local/bin/lazy-md
+```

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -1,0 +1,81 @@
+# Installing lazy-md on macOS
+
+## One-liner
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-macos.sh | bash
+```
+
+This downloads the latest pre-built binary and installs it to `/usr/local/bin`.
+
+To install to a custom directory:
+
+```bash
+INSTALL_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-macos.sh | bash
+```
+
+## Manual install (pre-built binary)
+
+1. Go to the [Releases](https://github.com/EME130/lazymd/releases) page
+2. Download the tarball for your Mac:
+   - `lazy-md-macos-aarch64.tar.gz` for Apple Silicon (M1/M2/M3/M4)
+   - `lazy-md-macos-x86_64.tar.gz` for Intel Macs
+3. Extract and install:
+
+```bash
+tar -xzf lazy-md-macos-aarch64.tar.gz
+sudo cp lazy-md /usr/local/bin/
+```
+
+If macOS Gatekeeper blocks the binary, remove the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine /usr/local/bin/lazy-md
+```
+
+## Build from source
+
+### Prerequisites
+
+Install Zig 0.15.1 or later:
+
+```bash
+# Option 1: Homebrew
+brew install zig
+
+# Option 2: From ziglang.org
+# Download from https://ziglang.org/download/ and extract to your PATH
+```
+
+Verify the installation:
+
+```bash
+zig version
+# Should output 0.15.1 or later
+```
+
+### Build
+
+```bash
+git clone https://github.com/EME130/lazymd.git
+cd lazymd
+zig build
+```
+
+The binary is at `zig-out/bin/lazy-md`. Copy it to your PATH:
+
+```bash
+sudo cp zig-out/bin/lazy-md /usr/local/bin/
+```
+
+## Verify
+
+```bash
+lazy-md --version
+```
+
+## Uninstall
+
+```bash
+sudo rm /usr/local/bin/lazy-md
+```

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -1,0 +1,98 @@
+# Installing lazy-md on Windows
+
+## One-liner (PowerShell)
+
+Run in PowerShell (as Administrator is **not** required):
+
+```powershell
+irm https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-windows.ps1 | iex
+```
+
+This downloads the latest pre-built binary and installs it to `%LOCALAPPDATA%\lazy-md`, then adds it to your user PATH.
+
+To install to a custom directory:
+
+```powershell
+$env:INSTALL_DIR = "C:\Tools\lazy-md"; irm https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-windows.ps1 | iex
+```
+
+## Manual install (pre-built binary)
+
+1. Go to the [Releases](https://github.com/EME130/lazymd/releases) page
+2. Download `lazy-md-windows-x86_64.zip`
+3. Extract the zip file
+4. Move `lazy-md.exe` to a directory in your PATH, or add its location to PATH:
+
+```powershell
+# Create install directory
+mkdir "$env:LOCALAPPDATA\lazy-md" -Force
+
+# Copy binary
+Copy-Item lazy-md.exe "$env:LOCALAPPDATA\lazy-md\"
+
+# Add to user PATH (persistent)
+$path = [Environment]::GetEnvironmentVariable("Path", "User")
+[Environment]::SetEnvironmentVariable("Path", "$path;$env:LOCALAPPDATA\lazy-md", "User")
+```
+
+Restart your terminal after modifying PATH.
+
+## Build from source
+
+### Prerequisites
+
+Install Zig 0.15.1 or later:
+
+**Option 1: winget**
+
+```powershell
+winget install zig.zig
+```
+
+**Option 2: Scoop**
+
+```powershell
+scoop install zig
+```
+
+**Option 3: Chocolatey**
+
+```powershell
+choco install zig
+```
+
+**Option 4: Manual download**
+
+Download from [ziglang.org/download](https://ziglang.org/download/), extract, and add to PATH.
+
+Verify the installation:
+
+```powershell
+zig version
+# Should output 0.15.1 or later
+```
+
+### Build
+
+```powershell
+git clone https://github.com/EME130/lazymd.git
+cd lazymd
+zig build
+```
+
+The binary is at `zig-out\bin\lazy-md.exe`. Add it to your PATH or copy it to an existing PATH directory.
+
+## Verify
+
+```powershell
+lazy-md --version
+```
+
+## Uninstall
+
+```powershell
+# Remove binary
+Remove-Item "$env:LOCALAPPDATA\lazy-md" -Recurse -Force
+
+# Remove from PATH (open System Properties > Environment Variables > edit user Path)
+```

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lazy-md installer for Linux
+# Usage: curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-linux.sh | bash
+
+REPO="EME130/lazymd"
+BINARY="lazy-md"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+info()  { printf '\033[1;34m%s\033[0m\n' "$*"; }
+error() { printf '\033[1;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)  ZIG_ARCH="x86_64" ;;
+    aarch64) ZIG_ARCH="aarch64" ;;
+    *)       error "Unsupported architecture: $ARCH. Supported: x86_64, aarch64" ;;
+esac
+
+ASSET="${BINARY}-linux-${ZIG_ARCH}.tar.gz"
+
+info "Installing ${BINARY} for Linux ${ZIG_ARCH}..."
+
+# Get latest release tag
+LATEST="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)"
+if [ -z "$LATEST" ]; then
+    error "Could not determine latest release. Check https://github.com/${REPO}/releases"
+fi
+info "Latest release: ${LATEST}"
+
+# Download
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ASSET}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "Downloading ${DOWNLOAD_URL}..."
+if ! curl -fSL --progress-bar -o "${TMPDIR}/${ASSET}" "$DOWNLOAD_URL"; then
+    error "Download failed. Asset '${ASSET}' may not exist for this release.\nTry building from source instead: https://github.com/${REPO}#install"
+fi
+
+# Extract
+info "Extracting..."
+tar -xzf "${TMPDIR}/${ASSET}" -C "$TMPDIR"
+
+# Install
+if [ -w "$INSTALL_DIR" ]; then
+    cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+    info "Installing to ${INSTALL_DIR} (requires sudo)..."
+    sudo cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+info "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"
+"${INSTALL_DIR}/${BINARY}" --version 2>/dev/null || true
+info "Done! Run '${BINARY}' to get started."

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# lazy-md installer for macOS
+# Usage: curl -fsSL https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-macos.sh | bash
+
+REPO="EME130/lazymd"
+BINARY="lazy-md"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+info()  { printf '\033[1;34m%s\033[0m\n' "$*"; }
+error() { printf '\033[1;31mError: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# Verify macOS
+if [ "$(uname -s)" != "Darwin" ]; then
+    error "This script is for macOS. Use install-linux.sh for Linux."
+fi
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+    arm64)   ZIG_ARCH="aarch64" ;;
+    x86_64)  ZIG_ARCH="x86_64" ;;
+    *)       error "Unsupported architecture: $ARCH. Supported: arm64 (Apple Silicon), x86_64 (Intel)" ;;
+esac
+
+ASSET="${BINARY}-macos-${ZIG_ARCH}.tar.gz"
+
+info "Installing ${BINARY} for macOS ${ZIG_ARCH}..."
+
+# Get latest release tag
+LATEST="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)"
+if [ -z "$LATEST" ]; then
+    error "Could not determine latest release. Check https://github.com/${REPO}/releases"
+fi
+info "Latest release: ${LATEST}"
+
+# Download
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ASSET}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info "Downloading ${DOWNLOAD_URL}..."
+if ! curl -fSL --progress-bar -o "${TMPDIR}/${ASSET}" "$DOWNLOAD_URL"; then
+    error "Download failed. Asset '${ASSET}' may not exist for this release.\nTry building from source instead: https://github.com/${REPO}#install"
+fi
+
+# Extract
+info "Extracting..."
+tar -xzf "${TMPDIR}/${ASSET}" -C "$TMPDIR"
+
+# Install
+if [ -w "$INSTALL_DIR" ]; then
+    cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+    info "Installing to ${INSTALL_DIR} (requires sudo)..."
+    sudo cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+# Remove quarantine attribute (macOS Gatekeeper)
+xattr -d com.apple.quarantine "${INSTALL_DIR}/${BINARY}" 2>/dev/null || true
+
+info "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"
+"${INSTALL_DIR}/${BINARY}" --version 2>/dev/null || true
+info "Done! Run '${BINARY}' to get started."

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,69 @@
+# lazy-md installer for Windows
+# Usage: irm https://raw.githubusercontent.com/EME130/lazymd/main/scripts/install-windows.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "EME130/lazymd"
+$Binary = "lazy-md"
+$InstallDir = if ($env:INSTALL_DIR) { $env:INSTALL_DIR } else { "$env:LOCALAPPDATA\lazy-md" }
+
+function Info($msg) { Write-Host $msg -ForegroundColor Cyan }
+function Err($msg) { Write-Host "Error: $msg" -ForegroundColor Red; exit 1 }
+
+# Detect architecture
+$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+switch ($Arch) {
+    "X64"   { $ZigArch = "x86_64" }
+    "Arm64" { $ZigArch = "aarch64" }
+    default { Err "Unsupported architecture: $Arch. Supported: X64, Arm64" }
+}
+
+$Asset = "$Binary-windows-$ZigArch.zip"
+
+Info "Installing $Binary for Windows $ZigArch..."
+
+# Get latest release tag
+try {
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ "User-Agent" = "lazy-md-installer" }
+    $Latest = $Release.tag_name
+} catch {
+    Err "Could not determine latest release. Check https://github.com/$Repo/releases"
+}
+Info "Latest release: $Latest"
+
+# Download
+$DownloadUrl = "https://github.com/$Repo/releases/download/$Latest/$Asset"
+$TmpDir = Join-Path $env:TEMP "lazy-md-install-$(Get-Random)"
+New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+Info "Downloading $DownloadUrl..."
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile "$TmpDir\$Asset" -UseBasicParsing
+} catch {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+    Err "Download failed. Asset '$Asset' may not exist for this release.`nTry building from source instead: https://github.com/$Repo#install"
+}
+
+# Extract
+Info "Extracting..."
+Expand-Archive -Path "$TmpDir\$Asset" -DestinationPath $TmpDir -Force
+
+# Install
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+Copy-Item "$TmpDir\$Binary.exe" "$InstallDir\$Binary.exe" -Force
+
+# Add to PATH if not already there
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    Info "Adding $InstallDir to user PATH..."
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    $env:Path = "$env:Path;$InstallDir"
+}
+
+# Cleanup
+Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+
+Info "Installed $Binary to $InstallDir\$Binary.exe"
+Info "Done! Restart your terminal, then run '$Binary' to get started."


### PR DESCRIPTION
- scripts/install-linux.sh: downloads latest release binary for x86_64/aarch64
- scripts/install-macos.sh: downloads latest release binary for Apple Silicon/Intel
- scripts/install-windows.ps1: downloads latest release zip and adds to user PATH
- docs/install-{linux,macos,windows}.md: detailed guides covering one-liner,
  manual binary install, and build-from-source with Zig prerequisites
- Updated README Install section with one-liner commands and guide links

https://claude.ai/code/session_01Gg9PcrFk5AoERy3SEnU8Qg