### PR TITLE
Update docs terminology for broader audience positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Add to `~/.gemini/settings.json`:
 
 - Built-in version control support
 - Extensible plugin system
-- ACP agent mode (host LazyMD as coding agent in Zed/JetBrains)
+- ACP agent mode (host LazyMD as agent in Zed/JetBrains)
 
 ## Slash Commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,12 +69,12 @@
 - Macros
 
 ### AI / MCP
-- ACP agent mode (host LazyMD as a coding agent in Zed/JetBrains)
+- ACP agent mode (host LazyMD as an agent in Zed/JetBrains)
 - AI-assisted writing within the editor
 - Context-aware tool suggestions
 
 ### Collaboration (LazyMD Cloud)
-- Real-time multiplayer editing (cooperative coding)
+- Real-time multiplayer editing (collaboration)
 - Shared vaults with role-based access
 - Rankings and contribution leaderboards
 - Built-in time tracking per file/project

--- a/scrach/growth-plan.md
+++ b/scrach/growth-plan.md
@@ -16,7 +16,7 @@
 Before any promotion, the editor must feel **solid** for daily use. Focus on:
 
 - **File sync between devices** — This is Obsidian's #1 pain point (paid Sync at $8/mo). Offer free git-based sync out of the box via your existing `git_sync` plugin. Market this hard.
-- **Smooth vim keybindings** — Your target audience (terminal users) expects flawless vim motions. This is table stakes.
+- **Smooth vim keybindings** — Your target audience expects flawless vim motions. This is table stakes.
 - **Fast startup** — Zig gives you a massive advantage here. Benchmark against Obsidian's Electron startup and flaunt the numbers.
 
 ### 1.2 Fix the README & Branding
@@ -149,7 +149,7 @@ Regular content keeps the project visible:
 - [ ] **MCP ecosystem** — Let AI agents build your second brain
 - [ ] **Speed** — Publish benchmarks: startup time, file open time, memory usage vs Obsidian
 - [ ] **Multiplayer via git** — Real-time(ish) collaboration through git branches
-- [ ] **ACP agent mode** (from your roadmap) — LazyMD as a coding agent host
+- [ ] **ACP agent mode** (from your roadmap) — LazyMD as an agent host
 
 ---
 

--- a/website/blog/2025-01-01-welcome.md
+++ b/website/blog/2025-01-01-welcome.md
@@ -8,7 +8,7 @@ keywords: [LazyMD, terminal markdown editor, vim editor, zig editor, open source
 
 Introducing LazyMD — a fast, terminal-based markdown editor written in Zig with vim keybindings, live preview, and zero dependencies.
 
-lm is built for developers who live in the terminal. If you use vim, tmux, and the command line every day, LazyMD fits right into your workflow. It features a 3-panel TUI layout inspired by lazygit, syntax highlighting for 16+ languages, 62 built-in plugins, and an MCP server that lets AI agents like Claude Code and Gemini CLI interact with your markdown documents.
+lm is built for thinkers who live in plain text. Whether you're a product engineer, founder, lawyer, researcher, or anyone who turns raw thought into structured clarity — LazyMD fits right into your workflow. It features a 3-panel TUI layout inspired by lazygit, syntax highlighting for 16+ languages, 62 built-in plugins, and an MCP server that lets AI agents like Claude Code and Gemini CLI interact with your markdown documents.
 
 <!-- truncate -->
 


### PR DESCRIPTION
## Summary
- Align blog, roadmap, growth plan, and CLAUDE.md with the website's repositioning from developer-focused to a broader audience
- Replace "built for developers" with "built for thinkers" in blog post, adding product engineers, founders, lawyers, researchers as examples
- Change "cooperative coding" to "collaboration" in roadmap
- Remove "coding" qualifier from "agent" references across docs

## Test plan
- [ ] Verify no remaining instances of "coding agent", "cooperative coding", or "built for developers" in docs
- [ ] Confirm markdown renders correctly in blog post

🤖 Generated with [Claude Code](https://claude.com/claude-code)