### PR TITLE
docs(website): replace Zig references with Go

### DIFF
--- a/website/blog/2025-01-01-welcome.md
+++ b/website/blog/2025-01-01-welcome.md
@@ -1,12 +1,12 @@
 ---
 title: "Introducing LazyMD: A Terminal Markdown Editor with Vim Keybindings"
 authors: [default]
-tags: [announcement, terminal-editor, vim, markdown, zig]
-description: "Introducing LazyMD — a fast, terminal-based markdown editor written in Zig with vim keybindings, live preview, syntax highlighting for 16+ languages, 62 built-in plugins, and an MCP server for AI agents."
-keywords: [LazyMD, terminal markdown editor, vim editor, zig editor, open source editor]
+tags: [announcement, terminal-editor, vim, markdown, go]
+description: "Introducing LazyMD — a fast, terminal-based markdown editor written in Go with vim keybindings, live preview, syntax highlighting for 16+ languages, built-in plugins, and an MCP server for AI agents."
+keywords: [LazyMD, terminal markdown editor, vim editor, go editor, open source editor]
 ---
 
-Introducing LazyMD — a fast, terminal-based markdown editor written in Zig with vim keybindings, live preview, and zero dependencies.
+Introducing LazyMD — a fast, terminal-based markdown editor written in Go with vim keybindings, live preview, and zero dependencies.
 
 lm is built for thinkers who live in plain text. Whether you're a product engineer, founder, lawyer, researcher, or anyone who turns raw thought into structured clarity — LazyMD fits right into your workflow. It features a 3-panel TUI layout inspired by lazygit, syntax highlighting for 16+ languages, 62 built-in plugins, and an MCP server that lets AI agents like Claude Code and Gemini CLI interact with your markdown documents.
 
@@ -20,15 +20,15 @@ lm is built for thinkers who live in plain text. Whether you're a product engine
 - **3-panel layout** — File tree, editor, and preview inspired by lazygit
 - **62 built-in plugins** — Zettelkasten, kanban, pomodoro, daily notes, zen mode, and more
 - **MCP server** — 15 tools for AI agent integration over JSON-RPC 2.0
-- **Zero dependencies** — Pure Zig, fast startup, tiny binary
+- **Zero dependencies** — Pure Go, fast startup, tiny binary
 
 ## Get Started
 
 ```bash
 git clone https://github.com/EME130/lazymd.git
 cd lazymd
-zig build
-./zig-out/bin/lm README.md
+go build ./cmd/lm
+./lm README.md
 ```
 
 Check out the [installation guide](/docs/getting-started/installation) and [quick start](/docs/getting-started/quick-start) to get running.

--- a/website/docs/configuration/themes.md
+++ b/website/docs/configuration/themes.md
@@ -54,4 +54,4 @@ All 12 themes include dedicated syntax highlighting colors for code blocks. Thes
 
 ### Supported Languages
 
-Syntax highlighting is available for 16 languages: Zig, Python, JavaScript, TypeScript, Rust, Go, C, C++, Bash, JSON, YAML, HTML, CSS, SQL, Lua, Ruby, and Java.
+Syntax highlighting is available for 16 languages: Go, Python, JavaScript, TypeScript, Rust, Zig, C, C++, Bash, JSON, YAML, HTML, CSS, SQL, Lua, Ruby, and Java.

--- a/website/docs/usage/brain-graph.md
+++ b/website/docs/usage/brain-graph.md
@@ -115,11 +115,11 @@ Find the most connected notes in the vault, ranked by total link count.
 ## Architecture
 
 ```
-src/brain/
-  Graph.zig     — Graph data structure (nodes, edges, backlinks, BFS neighbors)
-  Scanner.zig   — Recursive vault scanner with wiki-link extraction
-src/ui/
-  BrainView.zig — Force-directed ASCII graph panel with interactive navigation
+internal/brain/
+  graph.go      — Graph data structure (nodes, edges, backlinks, BFS neighbors)
+  scanner.go    — Recursive vault scanner with wiki-link extraction
+internal/ui/
+  brainview.go  — Force-directed ASCII graph panel with interactive navigation
 ```
 
 The graph is built once at startup by scanning the working directory. The force-directed layout runs iteratively until convergence (typically 30-50 iterations).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'LazyMD — The Editor of the Future',
-  tagline: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Zig with zero dependencies.',
+  tagline: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Go with zero dependencies.',
   favicon: 'img/favicon.ico',
 
   url: 'https://lazymd.com',
@@ -25,7 +25,7 @@ const config: Config = {
   headTags: [
     {
       tagName: 'meta',
-      attributes: {name: 'keywords', content: 'text editor, editor of the future, AI text editor, plain text editor, markdown editor, terminal editor, vim editor, zig editor, MCP server, LazyMD, lazymd, multi-platform editor, collaboration, team editor'},
+      attributes: {name: 'keywords', content: 'text editor, editor of the future, AI text editor, plain text editor, markdown editor, terminal editor, vim editor, go editor, MCP server, LazyMD, lazymd, multi-platform editor, collaboration, team editor'},
     },
     {
       tagName: 'meta',
@@ -43,7 +43,7 @@ const config: Config = {
         '@type': 'SoftwareApplication',
         name: 'LazyMD',
         url: 'https://lazymd.com',
-        description: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Zig with zero dependencies.',
+        description: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Go with zero dependencies.',
         applicationCategory: 'BusinessApplication',
         operatingSystem: 'Linux, macOS',
         offers: {
@@ -52,7 +52,7 @@ const config: Config = {
           priceCurrency: 'USD',
         },
         license: 'https://opensource.org/licenses/MIT',
-        programmingLanguage: 'Zig',
+        programmingLanguage: 'Go',
         codeRepository: 'https://github.com/EME130/lazymd',
       }),
     },
@@ -104,7 +104,7 @@ const config: Config = {
 
   themeConfig: {
     metadata: [
-      {name: 'description', content: 'LazyMD is the text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Zig with zero dependencies.'},
+      {name: 'description', content: 'LazyMD is the text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Go with zero dependencies.'},
       {property: 'og:type', content: 'website'},
       {property: 'og:site_name', content: 'LazyMD'},
       {property: 'og:title', content: 'LazyMD — The Editor of the Future'},
@@ -112,7 +112,7 @@ const config: Config = {
       {property: 'og:url', content: 'https://lazymd.com'},
       {name: 'twitter:card', content: 'summary_large_image'},
       {name: 'twitter:title', content: 'LazyMD — The Editor of the Future'},
-      {name: 'twitter:description', content: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere. Written in Zig.'},
+      {name: 'twitter:description', content: 'The text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere. Written in Go.'},
       {name: 'robots', content: 'index, follow'},
       {name: 'theme-color', content: '#10b981'},
     ],
@@ -172,7 +172,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['bash', 'zig', 'json', 'yaml'],
+      additionalLanguages: ['bash', 'go', 'json', 'yaml'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,7 @@ function Hero(): React.JSX.Element {
       <div className={s.heroInner}>
         <div className={s.heroTag}>
           <span className={s.heroTagDot} aria-hidden="true" />
-          Open Source &mdash; Written in Zig
+          Open Source &mdash; Written in Go
         </div>
         <h1 className={s.heroTitle}>
           The editor<br />
@@ -43,7 +43,7 @@ function Hero(): React.JSX.Element {
 /* ── Social Proof ─────────────────────────────────────────────────── */
 
 const badges: Array<[string, string]> = [
-  ['\u26A1', 'Written in Zig'],
+  ['\u26A1', 'Written in Go'],
   ['\u{1F517}', 'MCP Protocol'],
   ['\u2328', 'Vim Keybindings'],
   ['\u{1F4E6}', 'Single Binary'],
@@ -192,9 +192,9 @@ const features = [
   {icon: '\u2328', title: 'Vim-Native Editing', desc: 'Full modal editing with Normal, Insert, and Command modes. Navigate with hjkl, motions with w/b, delete with dd, undo with u \u2014 muscle-memory compatible.', wide: false},
   {icon: '\u25CE', title: 'Live Preview', desc: 'Rendered markdown in a side panel. Headers, bold, italic, code blocks with syntax highlighting \u2014 all updating as you type.', wide: false},
   {icon: '\u2588', title: 'Multi-Panel Layout', desc: 'Inspired by lazygit \u2014 file tree, editor, preview, and brain graph side by side. Toggle panels with Alt+1/2/3.', wide: false},
-  {icon: '\u2726', title: 'Syntax Highlighting', desc: 'Built-in highlighting for Zig, Python, JavaScript, TypeScript, Rust, Go, C, C++, Java, and 16+ languages. Theme-aware colors with a pluggable highlighter backend.', wide: true},
+  {icon: '\u2726', title: 'Syntax Highlighting', desc: 'Built-in highlighting for Go, Python, JavaScript, TypeScript, Rust, Zig, C, C++, Java, and 16+ languages. Theme-aware colors with a pluggable highlighter backend.', wide: true},
   {icon: '\u2699', title: 'Plugin System', desc: 'Register custom commands, hook into editor events, add panels. Build and share community plugins.', wide: false},
-  {icon: '\u2192', title: 'Zero Dependencies', desc: 'Pure Zig using only POSIX termios and ANSI escape codes. No runtime dependencies. Fast startup, tiny single binary.', wide: false},
+  {icon: '\u2192', title: 'Zero Dependencies', desc: 'Pure Go with Bubble Tea and Lip Gloss. No runtime dependencies. Fast startup, tiny single binary.', wide: false},
   {icon: '\u2387', title: 'Mouse Support', desc: 'Click to position cursor, scroll with mouse wheel, click panels to focus. Works in iTerm2, Alacritty, kitty, and more.', wide: false},
   {icon: '\u2B21', title: 'MCP Server', desc: 'Built-in Model Context Protocol server with 22 tools. AI agents like Claude Code and Gemini CLI connect via JSON-RPC 2.0 over stdio.', wide: false},
   {icon: '\u{1F9E0}', title: 'Brain: Knowledge Graph', desc: 'Obsidian-style graph view for [[wiki-links]]. Visualize connections between notes with a force-directed ASCII layout. Navigate, explore backlinks, and find orphan notes.', wide: true},
@@ -360,20 +360,20 @@ function Install(): React.JSX.Element {
           <div className={s.installCard}>
             <div className={s.installStep} aria-hidden="true">1</div>
             <h3>Prerequisites</h3>
-            <p>Install <a href="https://ziglang.org/download/">Zig</a> 0.15.1 or later from the official site.</p>
+            <p>Install <a href="https://go.dev/dl/">Go</a> 1.24.2 or later from the official site.</p>
           </div>
           <div className={s.installCard}>
             <div className={s.installStep} aria-hidden="true">2</div>
             <h3>Build</h3>
             <div className={s.codeBlock}>
-              <code>{`git clone https://github.com/\nEME130/lazymd.git\ncd lazymd && zig build`}</code>
+              <code>{`git clone https://github.com/\nEME130/lazymd.git\ncd lazymd && go build ./cmd/lm`}</code>
             </div>
           </div>
           <div className={s.installCard}>
             <div className={s.installStep} aria-hidden="true">3</div>
             <h3>Run</h3>
             <div className={s.codeBlock}>
-              <code>{`./zig-out/bin/lm myfile.md`}</code>
+              <code>{`./lm myfile.md`}</code>
             </div>
           </div>
         </div>
@@ -445,7 +445,7 @@ export default function Home(): React.JSX.Element {
   return (
     <Layout
       title="The Editor of the Future"
-      description="LazyMD is the text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Zig with zero dependencies.">
+      description="LazyMD is the text editor for thinkers in the AI era. Plain text is your alchemy. Runs everywhere — terminal, web, native apps, any device. Written in Go with zero dependencies.">
       <Head>
         <html lang="en" />
       </Head>


### PR DESCRIPTION
## Summary
- Updated all website pages, SEO metadata, blog post, and docs to replace Zig references with Go
- Fixed install instructions (Go 1.24.2+, `go build ./cmd/lm`), build commands, and binary paths
- Updated architecture paths in brain-graph docs from `src/*/File.zig` to `internal/*/file.go`
- Reordered syntax highlighting language lists to lead with Go

## Test plan
- [ ] Verify website builds without errors (`cd website && npm run build`)
- [ ] Check homepage hero, badges, features, and install section show Go references
- [ ] Confirm SEO meta tags and structured data reference Go
- [ ] Review blog post and docs pages for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)