### PR TITLE
chore(ci): simplify CI to single ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,13 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Build
-        run: go build ./...
 
       - name: Test
         run: go test ./...


### PR DESCRIPTION
## Summary
- Drop OS matrix (ubuntu + macos) in favor of single ubuntu runner
- Remove redundant `go build` step since `go test` implicitly builds

## Test plan
- [ ] Verify CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)